### PR TITLE
Add parallels for title, series

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+- '6.11'

--- a/lib/models/sierra-record.js
+++ b/lib/models/sierra-record.js
@@ -99,6 +99,7 @@ class SierraRecord {
         // Subfield 6 should always contain a parsable link, but, make sure..
         if (!parallelFieldLink) return ''
 
+        let direction = 'ltr'
         const parallelField = this.varField(parallelFieldLink.tag, subfields, {
           // Use preFilter so that we can filter on raw subfield data:
           preFilter: (block) => {
@@ -108,6 +109,11 @@ class SierraRecord {
             // Looking for the one varfield matching the uVal:
             const subFields = block['subFields'] || block['subfields']
             const subfield6 = (subFields.filter((s) => s.tag === '6').pop() || {}).content
+            const parallelFieldLink880 = SierraRecord.parseParallelFieldLink(subfield6)
+
+            // If 880 $u includes a direction suffix, grab it:
+            if (parallelFieldLink880.direction) direction = parallelFieldLink880.direction
+
             // 880 $6 values include extra info on end, so just match beginning
             return subfield6.indexOf(uVal) === 0
           }
@@ -116,7 +122,10 @@ class SierraRecord {
         // We've queried all matching parallel fields and there will be only
         // one (because we preFilter'd on $u === FIELD-NUM), so return the
         // only match (or undefined if for some reason the link is broken):
-        return parallelField.pop()
+        const value = parallelField.pop()
+        const directionControlPrefix = direction === 'rtl' ? '\u200F' : ''
+
+        return `${directionControlPrefix}${value}`
       })
 
     // Only return as many parallel values as necessary to preserve primary-
@@ -196,8 +205,12 @@ class SierraRecord {
 }
 
 SierraRecord.parseParallelFieldLink = function (subfield6) {
-  // Subfield 6 has form "[varfield]-[number]/...", e.g. "245-01/(2/r"
-  const parallelFieldLinkParts = subfield6.match(/^(\d+)-(\d+)/)
+  // Subfield 6 has form "[varfield]-[number]..."
+  // In 880 fields, it may include language and direction suffixes,
+  //   e.g. "245-01/(2/r", "100-01/(3/r"
+  // In primary field (e.g. 245 $u) it will be for ex. "245-01"
+  const parallelFieldLinkParts = subfield6.match(/^(\d+)-(\d+)(\/([^\/]+)\/(\w))?/)
+
   // This should never happen, but if $6 is malformed, return null:
   if (!parallelFieldLinkParts) return null
 
@@ -205,9 +218,15 @@ SierraRecord.parseParallelFieldLink = function (subfield6) {
   const tag = parallelFieldLinkParts[1]
   // Get the specific occurence number of the link (e.g. '01', '02', etc):
   const number = parallelFieldLinkParts[2]
+
+  // Read optional suffix. "r" indicates direction 'rtl'
+  let direction = 'ltr'
+  if (parallelFieldLinkParts.length === 6 && parallelFieldLinkParts[5] === 'r') direction = 'rtl'
+
   return {
     tag,
-    number
+    number,
+    direction
   }
 }
 

--- a/lib/models/sierra-record.js
+++ b/lib/models/sierra-record.js
@@ -67,6 +67,71 @@ class SierraRecord {
     }
   }
 
+  /**
+   * Get the 880 parallel fields for the given field.
+   *
+   * If there are no parallel fields, returns []
+   *
+   * Preserves primary-parallel index relationships, so if there are two
+   * parallel fields corresponding to the primary values 0 and 2, this will
+   * return an array with ['parallel for val 0', '', 'parallel for val 2']
+   *
+   * @example
+   * // This returns the parallel titles as an array in the same order of the
+   * // corresponding bib.literals('245', ..)
+   * bib.parallels('245', ['a', 'b'])
+   */
+  parallel (field, subfields) {
+    // Although we're querying into 880, first perform identical query against
+    // linked tag (e.g. 490), including subfield 6:
+    const primaryValues = this.varField(field, subfields.concat(['6']), { tagSubfields: true })
+    let parallelValues = primaryValues
+      .map((subfieldHash) => {
+        // Grab subfield 6:
+        const subfield6 = subfieldHash['6']
+        // If there is no $6, intentionally add '' to returned array
+        // because we presumably there's some primary value at this index,
+        // which just doesn't have a corresponding parallel value.
+        if (!subfield6) return ''
+
+        // Parse subfield $6 into tag and number (e.g. 880 & 01 respectively)
+        const parallelFieldLink = SierraRecord.parseParallelFieldLink(subfield6)
+        // Subfield 6 should always contain a parsable link, but, make sure..
+        if (!parallelFieldLink) return ''
+
+        const parallelField = this.varField(parallelFieldLink.tag, subfields, {
+          // Use preFilter so that we can filter on raw subfield data:
+          preFilter: (block) => {
+            // Establish the $u value we're looking for (e.g. 490-01)
+            const uVal = `${field}-${parallelFieldLink.number}`
+
+            // Looking for the one varfield matching the uVal:
+            const subFields = block['subFields'] || block['subfields']
+            const subfield6 = (subFields.filter((s) => s.tag === '6').pop() || {}).content
+            // 880 $6 values include extra info on end, so just match beginning
+            return subfield6.indexOf(uVal) === 0
+          }
+        })
+
+        // We've queried all matching parallel fields and there will be only
+        // one (because we preFilter'd on $u === FIELD-NUM), so return the
+        // only match (or undefined if for some reason the link is broken):
+        return parallelField.pop()
+      })
+
+    // Only return as many parallel values as necessary to preserve primary-
+    // parallel index relationships: Starting with last value, trim values off
+    // the end of the array until we find a non-empty parallel value:
+    for (let i = parallelValues.length - 1; i >= 0; i--) {
+      // If there's a parallel value at this index, stop slicing:
+      if (parallelValues[i]) break
+      // Pop a val off end because there are no truthy vals from this point on:
+      parallelValues.pop()
+    }
+
+    return parallelValues
+  }
+
   // Return content for given marc tag
   // if subfields given, returns content of those fields joined (or as a hash if opts.tagSubfields is truthy)
   // Options include:
@@ -127,6 +192,22 @@ class SierraRecord {
       })
       return [].concat.apply([], vals).filter((v) => v)
     } else return []
+  }
+}
+
+SierraRecord.parseParallelFieldLink = function (subfield6) {
+  // Subfield 6 has form "[varfield]-[number]/...", e.g. "245-01/(2/r"
+  const parallelFieldLinkParts = subfield6.match(/^(\d+)-(\d+)/)
+  // This should never happen, but if $6 is malformed, return null:
+  if (!parallelFieldLinkParts) return null
+
+  // Get the marc tag linked to by this 880 (e.g. '245')
+  const tag = parallelFieldLinkParts[1]
+  // Get the specific occurence number of the link (e.g. '01', '02', etc):
+  const number = parallelFieldLinkParts[2]
+  return {
+    tag,
+    number
   }
 }
 

--- a/lib/serializers/bib.js
+++ b/lib/serializers/bib.js
@@ -337,6 +337,21 @@ var fromMarcJson = (object, datasource) => {
       })
     })
 
+    // Add various parallel literals:
+    ; ['Parallel title', 'Parallel title display', 'Parallel series statement'].forEach((name) => {
+      fieldMapper.getMapping(name, (fieldMapping) => {
+        fieldMapping.paths.forEach((path) => {
+          const parallelValues = object.parallel(path.isParallelFor, path.subfields)
+          if (parallelValues && parallelValues.length > 0) {
+            parallelValues.forEach((parallelValue) => {
+              let sourceRecordPath = `880[$u^=${path.isParallelFor}] ${path.subfields.map((subfield) => `$${subfield}`).join(' ')}`
+              builder.add(fieldMapping.pred, { literal: parallelValue }, null, { path: sourceRecordPath })
+            })
+          }
+        })
+      })
+    })
+
     // LDR fields
     if (object.ldr()) {
       if (object.ldr().bibLevel) {

--- a/test/bib-marc-test.js
+++ b/test/bib-marc-test.js
@@ -33,7 +33,7 @@ describe('Bib Marc Mapping', function () {
       var bib = BibSierraRecord.from(require('./data/bib-11012182.json'))
 
       var val = bib.parallel('245', ['a', 'b'])
-      assert.equal(val[0], 'הרבי, שלושים שנות נשיאות /')
+      assert.equal(val[0], '\u200Fהרבי, שלושים שנות נשיאות /')
     })
 
     it('should parse parallel fields from bib with multiple 880s', function () {
@@ -831,8 +831,8 @@ describe('Bib Marc Mapping', function () {
       return bibSerializer.fromMarcJson(bib)
         .then((statements) => new Bib(statements))
         .then((bib) => {
-          assert.equal(bib.literal('nypl:parallelTitle'), 'הרבי, שלושים שנות נשיאות /')
-          assert.equal(bib.literal('nypl:parallelTitleDisplay'), 'הרבי, שלושים שנות נשיאות / [ערוכה, חנוך גליצנשטיין, עדין שטיינזלץ ; איסוף חומר, חנוך גליצנשטיין, ברקה וולף].')
+          assert.equal(bib.literal('nypl:parallelTitle'), '\u200Fהרבי, שלושים שנות נשיאות /')
+          assert.equal(bib.literal('nypl:parallelTitleDisplay'), '\u200Fהרבי, שלושים שנות נשיאות / [ערוכה, חנוך גליצנשטיין, עדין שטיינזלץ ; איסוף חומר, חנוך גליצנשטיין, ברקה וולף].')
         })
     })
 
@@ -856,7 +856,8 @@ describe('Bib Marc Mapping', function () {
         .then((bib) => {
           // Arabic is challenging to write expectations around for one not
           // fluent in arabic. Resorting to \u representation:
-          const expectedParallelTitleDisplay = [
+          // Include '\u200F' control character indicating RTL
+          const expectedParallelTitleDisplay = '\u200F' + [
             // Subfield a:
             '\u0643\u062A\u0627\u0628 \u0627\u0644\u0627\u0635\u0646\u0627\u0645 /',
             // Subfield c:
@@ -865,7 +866,7 @@ describe('Bib Marc Mapping', function () {
           assert.equal(bib.literal('nypl:parallelTitleDisplay'), expectedParallelTitleDisplay)
 
           // Join subfields "3","a","x","v","l":
-          const expectedParallelSeriesStatement = [
+          const expectedParallelSeriesStatement = '\u200F' + [
             // Subfield a:
             '\u0645\u0643\u062A\u0628\u0629 \u0627\u0644\u0639\u0631\u0628\u064A\u0629 \u061B',
             // Subfield v:
@@ -882,6 +883,7 @@ describe('Bib Marc Mapping', function () {
           assert.equal(bib.literal('nypl:parallelSeriesStatement'), expectedParallelSeriesStatement)
         })
     })
+
     it('should parse Notes blank nodes correctly', function () {
       var bib = BibSierraRecord.from(require('./data/bib-18064236.json'))
 

--- a/test/data/bib-11009512.json
+++ b/test/data/bib-11009512.json
@@ -1,0 +1,868 @@
+{
+  "id": "11009512",
+  "nyplSource": "sierra-nypl",
+  "nyplType": "bib",
+  "updatedDate": "2012-03-09T01:35:14-05:00",
+  "createdDate": "2008-12-14T15:49:25-05:00",
+  "deletedDate": null,
+  "deleted": false,
+  "locations": [
+    {
+      "code": "mal",
+      "name": "SASB - Service Desk Rm 315"
+    }
+  ],
+  "suppressed": false,
+  "lang": {
+    "code": "chi",
+    "name": "Chinese"
+  },
+  "title": "Li Hongzhang li pin Ou Mei ji",
+  "author": "",
+  "materialType": {
+    "code": "a",
+    "value": "BOOK/TEXT"
+  },
+  "bibLevel": {
+    "code": "m",
+    "value": "MONOGRAPH"
+  },
+  "publishYear": 1982,
+  "catalogDate": "2002-12-06",
+  "country": {
+    "code": "cc ",
+    "name": "China"
+  },
+  "normTitle": "li hongzhang li pin ou mei ji",
+  "normAuthor": "",
+  "standardNumbers": [],
+  "controlNumber": "NYPO86-B2017",
+  "fixedFields": {
+    "24": {
+      "label": "Language",
+      "value": "chi",
+      "display": "Chinese"
+    },
+    "25": {
+      "label": "Skip",
+      "value": "0",
+      "display": null
+    },
+    "26": {
+      "label": "Location",
+      "value": "mal  ",
+      "display": "SASB - Service Desk Rm 315"
+    },
+    "27": {
+      "label": "COPIES",
+      "value": "1",
+      "display": null
+    },
+    "28": {
+      "label": "Cat. Date",
+      "value": "2002-12-06",
+      "display": null
+    },
+    "29": {
+      "label": "Bib Level",
+      "value": "m",
+      "display": "MONOGRAPH"
+    },
+    "30": {
+      "label": "Material Type",
+      "value": "a",
+      "display": "BOOK/TEXT"
+    },
+    "31": {
+      "label": "Bib Code 3",
+      "value": "-",
+      "display": null
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "b",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "11009512",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": "2008-12-14T15:49:25Z",
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2012-03-09T01:35:14Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": "9",
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "1",
+      "display": null
+    },
+    "89": {
+      "label": "Country",
+      "value": "cc ",
+      "display": "China"
+    },
+    "98": {
+      "label": "PDATE",
+      "value": "2012-02-03T23:51:33Z",
+      "display": null
+    },
+    "107": {
+      "label": "MARC Type",
+      "value": " ",
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-07"
+        },
+        {
+          "tag": "a",
+          "content": "Cai, Erkang."
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Allen, Young John,"
+        },
+        {
+          "tag": "d",
+          "content": "1836-1907."
+        }
+      ]
+    },
+    {
+      "fieldTag": "c",
+      "marcTag": "852",
+      "ind1": "8",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "h",
+          "content": "*OVO 86-1818"
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "600",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-05"
+        },
+        {
+          "tag": "a",
+          "content": "Li, Hongzhang,"
+        },
+        {
+          "tag": "d",
+          "content": "1823-1901"
+        },
+        {
+          "tag": "x",
+          "content": "Travel"
+        },
+        {
+          "tag": "z",
+          "content": "Europe."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "600",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-06"
+        },
+        {
+          "tag": "a",
+          "content": "Li, Hongzhang,"
+        },
+        {
+          "tag": "d",
+          "content": "1823-1901"
+        },
+        {
+          "tag": "x",
+          "content": "Travel"
+        },
+        {
+          "tag": "z",
+          "content": "United States."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "651",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Europe"
+        },
+        {
+          "tag": "x",
+          "content": "Description and travel."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "651",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "United States"
+        },
+        {
+          "tag": "x",
+          "content": "Description and travel."
+        }
+      ]
+    },
+    {
+      "fieldTag": "e",
+      "marcTag": "250",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-02"
+        },
+        {
+          "tag": "a",
+          "content": "Di 1 ban."
+        }
+      ]
+    },
+    {
+      "fieldTag": "l",
+      "marcTag": "010",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "83127784 /ACN"
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Rev. ed. of: Li fu xiang li pin Ou Mei ji / Shanghai guang xue hui yi zhu. 1899."
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "546",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "In Chinese."
+        }
+      ]
+    },
+    {
+      "fieldTag": "o",
+      "marcTag": "001",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "NYPO86-B2017",
+      "subfields": null
+    },
+    {
+      "fieldTag": "p",
+      "marcTag": "260",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-03"
+        },
+        {
+          "tag": "a",
+          "content": "Changsha Shi :"
+        },
+        {
+          "tag": "b",
+          "content": "Hunan ren min chu ban she :"
+        },
+        {
+          "tag": "b",
+          "content": "Hunan sheng xin hua shu dian fa xing,"
+        },
+        {
+          "tag": "c",
+          "content": "1982."
+        }
+      ]
+    },
+    {
+      "fieldTag": "q",
+      "marcTag": "852",
+      "ind1": "8",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "h",
+          "content": "*OVO 86-1818"
+        }
+      ]
+    },
+    {
+      "fieldTag": "r",
+      "marcTag": "300",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "3, 260 p., [8] p. of plates :"
+        },
+        {
+          "tag": "b",
+          "content": "ill. ;"
+        },
+        {
+          "tag": "c",
+          "content": "19 cm."
+        }
+      ]
+    },
+    {
+      "fieldTag": "s",
+      "marcTag": "440",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-04"
+        },
+        {
+          "tag": "a",
+          "content": "Zou xiang shi jie cong shu"
+        }
+      ]
+    },
+    {
+      "fieldTag": "t",
+      "marcTag": "245",
+      "ind1": "0",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-01"
+        },
+        {
+          "tag": "a",
+          "content": "Li Hongzhang li pin Ou Mei ji /"
+        },
+        {
+          "tag": "c",
+          "content": "Cai Erkang, Lin Lezhi bian yi ; Zhang Yingyu dian ; Zhang Xuanhao jiao."
+        }
+      ]
+    },
+    {
+      "fieldTag": "u",
+      "marcTag": "730",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-08"
+        },
+        {
+          "tag": "a",
+          "content": "Li fu xiang li pin Ou Mei ji."
+        }
+      ]
+    },
+    {
+      "fieldTag": "v",
+      "marcTag": "959",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": ".b20293185"
+        },
+        {
+          "tag": "b",
+          "content": "01-10-08"
+        },
+        {
+          "tag": "c",
+          "content": "08-23-91"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "003",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "CStRLIN",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "005",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "20021115110330.0",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "008",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "860616s1982    cc af         00000bchi  camua ",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "040",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "d",
+          "content": "CStRLIN"
+        },
+        {
+          "tag": "d",
+          "content": "NhD"
+        },
+        {
+          "tag": "d",
+          "content": "MnU"
+        },
+        {
+          "tag": "d",
+          "content": "NN"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "043",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "e------"
+        },
+        {
+          "tag": "a",
+          "content": "n-us---"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "050",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "DS763.63.L5"
+        },
+        {
+          "tag": "b",
+          "content": "L54 1982"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "908",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "DS763.63.L5"
+        },
+        {
+          "tag": "b",
+          "content": "L54 1982"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "066",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "c",
+          "content": "$1"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "082",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "951/.03/0924"
+        },
+        {
+          "tag": "2",
+          "content": "19"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "0",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "245-01/$1"
+        },
+        {
+          "tag": "a",
+          "content": "李鸿章历聘欧美记 /"
+        },
+        {
+          "tag": "c",
+          "content": "蔡尔康, 林乐知编译 ; 张英宇点 ; 张玄浩校."
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "250-02/$1"
+        },
+        {
+          "tag": "a",
+          "content": "第1版."
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "260-03/$1"
+        },
+        {
+          "tag": "a",
+          "content": "长沙市 :"
+        },
+        {
+          "tag": "b",
+          "content": "湖南人民出版社 :"
+        },
+        {
+          "tag": "b",
+          "content": "湖南省新華書店发行,"
+        },
+        {
+          "tag": "c",
+          "content": "1982."
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "440-04/$1"
+        },
+        {
+          "tag": "a",
+          "content": "走向世界叢書"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "600-05/$1"
+        },
+        {
+          "tag": "a",
+          "content": "李鸿章,"
+        },
+        {
+          "tag": "d",
+          "content": "1823-1901"
+        },
+        {
+          "tag": "x",
+          "content": "Travel"
+        },
+        {
+          "tag": "z",
+          "content": "Europe."
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "600-06/$1"
+        },
+        {
+          "tag": "a",
+          "content": "李鸿章,"
+        },
+        {
+          "tag": "d",
+          "content": "1823-1901"
+        },
+        {
+          "tag": "x",
+          "content": "Travel"
+        },
+        {
+          "tag": "z",
+          "content": "United States."
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "700-07/$1"
+        },
+        {
+          "tag": "a",
+          "content": "蔡尔康."
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "730-08/$1"
+        },
+        {
+          "tag": "a",
+          "content": "李傅相历聘欧美记."
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "987",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "PINYIN"
+        },
+        {
+          "tag": "b",
+          "content": "CStRLIN"
+        },
+        {
+          "tag": "c",
+          "content": "20010108"
+        },
+        {
+          "tag": "d",
+          "content": "c"
+        },
+        {
+          "tag": "e",
+          "content": "1.0"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "997",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "ho"
+        },
+        {
+          "tag": "b",
+          "content": "12-06-02"
+        },
+        {
+          "tag": "c",
+          "content": "m"
+        },
+        {
+          "tag": "d",
+          "content": "a"
+        },
+        {
+          "tag": "e",
+          "content": "-"
+        },
+        {
+          "tag": "f",
+          "content": "chi"
+        },
+        {
+          "tag": "g",
+          "content": "cc "
+        },
+        {
+          "tag": "h",
+          "content": "0"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "991",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "y",
+          "content": "10123100"
+        }
+      ]
+    },
+    {
+      "fieldTag": "_",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "00000cam  2200469ua 4500",
+      "subfields": null
+    }
+  ]
+}

--- a/test/data/bib-11012182.json
+++ b/test/data/bib-11012182.json
@@ -1,0 +1,727 @@
+{
+  "id": "11012182",
+  "nyplSource": "sierra-nypl",
+  "nyplType": "bib",
+  "updatedDate": "2012-06-05T17:53:52-04:00",
+  "createdDate": "2008-12-14T15:52:00-05:00",
+  "deletedDate": null,
+  "deleted": false,
+  "locations": [
+    {
+      "code": "maf",
+      "name": "SASB - Dorot Jewish Division Rm 111"
+    }
+  ],
+  "suppressed": false,
+  "lang": {
+    "code": "heb",
+    "name": "Hebrew"
+  },
+  "title": "ha-Rebi, sheloshim shenot neśiʼut.",
+  "author": "",
+  "materialType": {
+    "code": "a",
+    "value": "BOOK/TEXT"
+  },
+  "bibLevel": {
+    "code": "m",
+    "value": "MONOGRAPH"
+  },
+  "publishYear": 1980,
+  "catalogDate": "2000-10-19",
+  "country": {
+    "code": "is ",
+    "name": "Israel"
+  },
+  "normTitle": "ha rebi sheloshim shenot neśiʼut",
+  "normAuthor": "",
+  "standardNumbers": [],
+  "controlNumber": "NYPX86-B2366",
+  "fixedFields": {
+    "24": {
+      "label": "Language",
+      "value": "heb",
+      "display": "Hebrew"
+    },
+    "25": {
+      "label": "Skip",
+      "value": "3",
+      "display": null
+    },
+    "26": {
+      "label": "Location",
+      "value": "maf  ",
+      "display": "SASB - Dorot Jewish Division Rm 111"
+    },
+    "27": {
+      "label": "COPIES",
+      "value": "1",
+      "display": null
+    },
+    "28": {
+      "label": "Cat. Date",
+      "value": "2000-10-19",
+      "display": null
+    },
+    "29": {
+      "label": "Bib Level",
+      "value": "m",
+      "display": "MONOGRAPH"
+    },
+    "30": {
+      "label": "Material Type",
+      "value": "a",
+      "display": "BOOK/TEXT"
+    },
+    "31": {
+      "label": "Bib Code 3",
+      "value": "-",
+      "display": null
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "b",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "11012182",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": "2008-12-14T15:52:00Z",
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2012-06-05T17:53:52Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": "6",
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "1",
+      "display": null
+    },
+    "89": {
+      "label": "Country",
+      "value": "is ",
+      "display": "Israel"
+    },
+    "98": {
+      "label": "PDATE",
+      "value": "2012-01-11T12:12:37Z",
+      "display": null
+    },
+    "107": {
+      "label": "MARC Type",
+      "value": " ",
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-04."
+        },
+        {
+          "tag": "a",
+          "content": "Glitsenshṭain, Avraham Ḥanokh,"
+        },
+        {
+          "tag": "d",
+          "content": "1929-"
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-05."
+        },
+        {
+          "tag": "a",
+          "content": "Steinsaltz, Adin."
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-06."
+        },
+        {
+          "tag": "a",
+          "content": "Wolf, Berka."
+        }
+      ]
+    },
+    {
+      "fieldTag": "c",
+      "marcTag": "852",
+      "ind1": "8",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "h",
+          "content": "*PWZ (Schneersohn, M.) 85-1961"
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "600",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-03."
+        },
+        {
+          "tag": "a",
+          "content": "Schneerson, Menachem Mendel,"
+        },
+        {
+          "tag": "d",
+          "content": "1902-1994."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Habad."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Rabbis"
+        },
+        {
+          "tag": "z",
+          "content": "New York (State)"
+        },
+        {
+          "tag": "z",
+          "content": "New York"
+        },
+        {
+          "tag": "v",
+          "content": "Biography."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Hasidim"
+        },
+        {
+          "tag": "z",
+          "content": "New York (State)"
+        },
+        {
+          "tag": "z",
+          "content": "New York"
+        },
+        {
+          "tag": "v",
+          "content": "Biography."
+        }
+      ]
+    },
+    {
+      "fieldTag": "l",
+      "marcTag": "010",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "81175425"
+        }
+      ]
+    },
+    {
+      "fieldTag": "l",
+      "marcTag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "(WaOLN)nyp1019480"
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Title on added t.p.: Rebbe, thirty years of leadership."
+        }
+      ]
+    },
+    {
+      "fieldTag": "o",
+      "marcTag": "001",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "NYPX86-B2366",
+      "subfields": null
+    },
+    {
+      "fieldTag": "p",
+      "marcTag": "260",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-02"
+        },
+        {
+          "tag": "a",
+          "content": "[Ḥ. m.] :"
+        },
+        {
+          "tag": "b",
+          "content": "Ṿaʻad hotsaʼat sefer ha-yovel li-shenot ha-sheloshim,"
+        },
+        {
+          "tag": "c",
+          "content": "[0"
+        }
+      ]
+    },
+    {
+      "fieldTag": "q",
+      "marcTag": "852",
+      "ind1": "8",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "h",
+          "content": "*PWZ (Schneersohn, M.) 85-1961"
+        }
+      ]
+    },
+    {
+      "fieldTag": "r",
+      "marcTag": "300",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "345 p., [28] p. of plates :"
+        },
+        {
+          "tag": "b",
+          "content": "ill., ports.;"
+        },
+        {
+          "tag": "c",
+          "content": "28 cm."
+        }
+      ]
+    },
+    {
+      "fieldTag": "t",
+      "marcTag": "245",
+      "ind1": "0",
+      "ind2": "3",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-01"
+        },
+        {
+          "tag": "a",
+          "content": "ha-Rebi, sheloshim shenot neśiʼut."
+        }
+      ]
+    },
+    {
+      "fieldTag": "u",
+      "marcTag": "740",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Rebbe, thirty years of leadership."
+        }
+      ]
+    },
+    {
+      "fieldTag": "u",
+      "marcTag": "740",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Rabi, sheloshim shenot neśiʼut."
+        }
+      ]
+    },
+    {
+      "fieldTag": "v",
+      "marcTag": "959",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": ".b20320097"
+        },
+        {
+          "tag": "b",
+          "content": "04-10-07"
+        },
+        {
+          "tag": "c",
+          "content": "08-23-91"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "003",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "CStRLIN",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "005",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "20000629175403.0",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "008",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "860730s1980    is co         000 0bheb  cam a ",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "040",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "c",
+          "content": "NN"
+        },
+        {
+          "tag": "d",
+          "content": "NN"
+        },
+        {
+          "tag": "d",
+          "content": "WaOLN"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "050",
+      "ind1": "0",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "BM755.S288"
+        },
+        {
+          "tag": "b",
+          "content": "R35"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "066",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "c",
+          "content": "(2"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "0",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "245-01/(2/r"
+        },
+        {
+          "tag": "a",
+          "content": "הרבי, שלושים שנות נשיאות /"
+        },
+        {
+          "tag": "c",
+          "content": "[ערוכה, חנוך גליצנשטיין, עדין שטיינזלץ ; איסוף חומר, חנוך גליצנשטיין, ברקה וולף]."
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "260-02/(2/r"
+        },
+        {
+          "tag": "a",
+          "content": "[ח\"מ] :"
+        },
+        {
+          "tag": "b",
+          "content": "ועד הוצאת ספר היובל לשנות השלושים,"
+        },
+        {
+          "tag": "c",
+          "content": "[0891]"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "1",
+      "ind2": "4",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "600-03/(2/r"
+        },
+        {
+          "tag": "a",
+          "content": "שניאורסאהן, מנחם מנדל,"
+        },
+        {
+          "tag": "d",
+          "content": "2091-4991."
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "700-04/(2/r"
+        },
+        {
+          "tag": "a",
+          "content": "גליצנשטיין, אברהם חנוך,"
+        },
+        {
+          "tag": "d",
+          "content": "9191-"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "700-05/(2/r"
+        },
+        {
+          "tag": "a",
+          "content": "שטיינזלץ, עדין."
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "700-06/(2/r"
+        },
+        {
+          "tag": "a",
+          "content": "וולף, ברקה."
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "908",
+      "ind1": "0",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "BM755.S288"
+        },
+        {
+          "tag": "b",
+          "content": "R35"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "997",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "hj"
+        },
+        {
+          "tag": "b",
+          "content": "10-19-00"
+        },
+        {
+          "tag": "c",
+          "content": "m"
+        },
+        {
+          "tag": "d",
+          "content": "a"
+        },
+        {
+          "tag": "e",
+          "content": "-"
+        },
+        {
+          "tag": "f",
+          "content": "heb"
+        },
+        {
+          "tag": "g",
+          "content": "is "
+        },
+        {
+          "tag": "h",
+          "content": "3"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "991",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "y",
+          "content": "17040741"
+        }
+      ]
+    },
+    {
+      "fieldTag": "_",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "00000cam  2200397 a 4500",
+      "subfields": null
+    }
+  ]
+}

--- a/test/data/bib-19683865.json
+++ b/test/data/bib-19683865.json
@@ -1,0 +1,813 @@
+{
+  "id": "19683865",
+  "nyplSource": "sierra-nypl",
+  "nyplType": "bib",
+  "updatedDate": "2016-01-20T23:33:56-05:00",
+  "createdDate": "2012-09-07T14:15:07-04:00",
+  "deletedDate": null,
+  "deleted": false,
+  "locations": [
+    {
+      "code": "mal",
+      "name": "SASB - Service Desk Rm 315"
+    }
+  ],
+  "suppressed": false,
+  "lang": {
+    "code": "ara",
+    "name": "Arabic"
+  },
+  "title": "Kitāb al-aṣnām",
+  "author": "Ibn al-Kalbī, d. 819?",
+  "materialType": {
+    "code": "a",
+    "value": "BOOK/TEXT"
+  },
+  "bibLevel": {
+    "code": "m",
+    "value": "MONOGRAPH"
+  },
+  "publishYear": 1965,
+  "catalogDate": "2012-09-07",
+  "country": {
+    "code": "ua ",
+    "name": "Egypt"
+  },
+  "normTitle": "kitāb al aṣnām",
+  "normAuthor": "ibn al kalbī d 819",
+  "standardNumbers": [],
+  "controlNumber": "23494481",
+  "fixedFields": {
+    "24": {
+      "label": "Language",
+      "value": "ara",
+      "display": "Arabic"
+    },
+    "25": {
+      "label": "Skip",
+      "value": "0",
+      "display": null
+    },
+    "26": {
+      "label": "Location",
+      "value": "mal  ",
+      "display": "SASB - Service Desk Rm 315"
+    },
+    "27": {
+      "label": "COPIES",
+      "value": "1",
+      "display": null
+    },
+    "28": {
+      "label": "Cat. Date",
+      "value": "2012-09-07",
+      "display": null
+    },
+    "29": {
+      "label": "Bib Level",
+      "value": "m",
+      "display": "MONOGRAPH"
+    },
+    "30": {
+      "label": "Material Type",
+      "value": "a",
+      "display": "BOOK/TEXT"
+    },
+    "31": {
+      "label": "Bib Code 3",
+      "value": "-",
+      "display": null
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "b",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "19683865",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": "2012-09-07T14:15:07Z",
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2016-01-20T23:33:56Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": "6",
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "1",
+      "display": null
+    },
+    "89": {
+      "label": "Country",
+      "value": "ua ",
+      "display": "Egypt"
+    },
+    "98": {
+      "label": "PDATE",
+      "value": "2016-01-01T14:09:24Z",
+      "display": null
+    },
+    "107": {
+      "label": "MARC Type",
+      "value": " ",
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "fieldTag": "a",
+      "marcTag": "100",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-01"
+        },
+        {
+          "tag": "a",
+          "content": "Ibn al-Kalbī,"
+        },
+        {
+          "tag": "d",
+          "content": "d. 819?"
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-07"
+        },
+        {
+          "tag": "a",
+          "content": "Aḥmad Zakī,"
+        },
+        {
+          "tag": "d",
+          "content": "1866 (ca.)-1934."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Idols and images"
+        },
+        {
+          "tag": "x",
+          "content": "Worship."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Arab cults."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "651",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Arabian Peninsula"
+        },
+        {
+          "tag": "x",
+          "content": "Religion."
+        }
+      ]
+    },
+    {
+      "fieldTag": "l",
+      "marcTag": "010",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "ne 65002370"
+        }
+      ]
+    },
+    {
+      "fieldTag": "l",
+      "marcTag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "(OCoLC)23494481"
+        }
+      ]
+    },
+    {
+      "fieldTag": "o",
+      "marcTag": "001",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "23494481 ",
+      "subfields": null
+    },
+    {
+      "fieldTag": "p",
+      "marcTag": "260",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-05"
+        },
+        {
+          "tag": "a",
+          "content": "al-Qāhirah :"
+        },
+        {
+          "tag": "b",
+          "content": "al-Dār al-Qawmīyah lil-Ṭibāʻah wa-al-Nashr,"
+        },
+        {
+          "tag": "c",
+          "content": "1965."
+        }
+      ]
+    },
+    {
+      "fieldTag": "q",
+      "marcTag": "852",
+      "ind1": "8",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "h",
+          "content": "*OGN (Kalbī. Kitāb al-aṣnām)"
+        }
+      ]
+    },
+    {
+      "fieldTag": "r",
+      "marcTag": "300",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "111, iv p. :"
+        },
+        {
+          "tag": "b",
+          "content": "facsims. ;"
+        },
+        {
+          "tag": "c",
+          "content": "27 cm."
+        }
+      ]
+    },
+    {
+      "fieldTag": "s",
+      "marcTag": "490",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-06"
+        },
+        {
+          "tag": "a",
+          "content": "Maktabah al-ʻArabīyah ;"
+        },
+        {
+          "tag": "v",
+          "content": "21."
+        },
+        {
+          "tag": "a",
+          "content": "Taḥqīq al-turāth al-ʻArabī,"
+        },
+        {
+          "tag": "v",
+          "content": "7."
+        },
+        {
+          "tag": "a",
+          "content": "Adab ;"
+        },
+        {
+          "tag": "v",
+          "content": "12"
+        }
+      ]
+    },
+    {
+      "fieldTag": "t",
+      "marcTag": "245",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-03"
+        },
+        {
+          "tag": "a",
+          "content": "Kitāb al-aṣnām /"
+        },
+        {
+          "tag": "c",
+          "content": "ʻan Abī al-Mundhir Hishām ibn Muḥammad al-Sāʼib al-Kalbī, ubqan lil-naskhah al-waḥīdah al-maḥfūẓah bi-al-khāznah al-zakīyah ; bi-taḥqīq Aḥmad Zakī."
+        }
+      ]
+    },
+    {
+      "fieldTag": "t",
+      "marcTag": "240",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Aṣnām"
+        }
+      ]
+    },
+    {
+      "fieldTag": "u",
+      "marcTag": "246",
+      "ind1": "3",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-04"
+        },
+        {
+          "tag": "a",
+          "content": "Aṣnām"
+        }
+      ]
+    },
+    {
+      "fieldTag": "w",
+      "marcTag": "776",
+      "ind1": "0",
+      "ind2": "8",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "i",
+          "content": "Online version:"
+        },
+        {
+          "tag": "a",
+          "content": "Ibn al-Kalbī, d. 819?"
+        },
+        {
+          "tag": "s",
+          "content": "Aṣnām."
+        },
+        {
+          "tag": "t",
+          "content": "Kitāb al-aṣnām."
+        },
+        {
+          "tag": "d",
+          "content": "al-Qāhirah : al-Dār al-Qawmīyah lil-Ṭibāʻah wa-al-Nashr, 1965"
+        },
+        {
+          "tag": "w",
+          "content": "(OCoLC)607923424"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "003",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "OCoLC",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "005",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "20120906140711.0",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "008",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "890510s1965    ua h          000 0 arar cam1a ",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "040",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "DLC"
+        },
+        {
+          "tag": "c",
+          "content": "EYM"
+        },
+        {
+          "tag": "d",
+          "content": "DLC"
+        },
+        {
+          "tag": "d",
+          "content": "OCLCG"
+        },
+        {
+          "tag": "d",
+          "content": "IUL"
+        },
+        {
+          "tag": "d",
+          "content": "NYP"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "043",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "ar-----"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "049",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "NYPP"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "050",
+      "ind1": "0",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "BL1685"
+        },
+        {
+          "tag": "b",
+          "content": ".I2 1965"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "908",
+      "ind1": "0",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "BL1685"
+        },
+        {
+          "tag": "b",
+          "content": ".I2 1965"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "066",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "c",
+          "content": "(3"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "100-01/(3/r"
+        },
+        {
+          "tag": "a",
+          "content": "ابن الكلبي."
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "240-02/(3/r"
+        },
+        {
+          "tag": "a",
+          "content": "اصنام"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "245-03/(3/r"
+        },
+        {
+          "tag": "a",
+          "content": "كتاب الاصنام /"
+        },
+        {
+          "tag": "c",
+          "content": "عن ابي المنذر هشام بن محمد بن السايب الكلبي, طبقا للنسخة الوحيدة المحفوظة بالخزانة الزكية ؛ بتحقيق احمد زكي."
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "3",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "246-04/(3/r"
+        },
+        {
+          "tag": "a",
+          "content": "اصنام"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "260-05/(3/r"
+        },
+        {
+          "tag": "a",
+          "content": "القاهرة :"
+        },
+        {
+          "tag": "b",
+          "content": "الدار القومية للطباعة والنشر,"
+        },
+        {
+          "tag": "c",
+          "content": "1965."
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "490-06/(3/r"
+        },
+        {
+          "tag": "a",
+          "content": "مكتبة العربية ؛"
+        },
+        {
+          "tag": "v",
+          "content": "21."
+        },
+        {
+          "tag": "a",
+          "content": "تحقيق التراث العربي ؛"
+        },
+        {
+          "tag": "v",
+          "content": "7."
+        },
+        {
+          "tag": "a",
+          "content": "ادب ؛"
+        },
+        {
+          "tag": "v",
+          "content": "12"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "700-07/(3/r"
+        },
+        {
+          "tag": "a",
+          "content": "احمد زكي."
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "901",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "als"
+        },
+        {
+          "tag": "b",
+          "content": "CATRL"
+        },
+        {
+          "tag": "n",
+          "content": "BarCAT"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "901",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "MARS"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "946",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "m"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "*OGN (Kalbī. Kitāb al-aṣnām)"
+        },
+        {
+          "tag": "i",
+          "content": "33433101157307"
+        },
+        {
+          "tag": "l",
+          "content": "mal62"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "t",
+          "content": "055"
+        },
+        {
+          "tag": "h",
+          "content": "033"
+        },
+        {
+          "tag": "o",
+          "content": "1"
+        },
+        {
+          "tag": "v",
+          "content": "CATRL/als/BarCAT"
+        }
+      ]
+    },
+    {
+      "fieldTag": "_",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "00000cam  22004811a 4500",
+      "subfields": null
+    }
+  ]
+}


### PR DESCRIPTION
Adds new `SierraRecord.parallel` model method for extracting parallel
field values based on the primary field values.

Adds extraction of parallelTitle, parallelTitleDisplay, and
parallelSeriesStatement, with tests. Adds '\u200F' prefix to RTL values.