### PR TITLE
 Patch loglevel bug, limit IndexDocumentQueue hits

### DIFF
--- a/lib/bibs-updater.js
+++ b/lib/bibs-updater.js
@@ -143,10 +143,7 @@ class BibsUpdater extends UpdaterBase {
           log.debug('Statements: ', statements)
           // Report on success
           // Get distinct subject_ids:
-          var num = Object.keys(statements.reduce((h, statement) => {
-            h[statement.subject_id] = true
-            return h
-          }, {})).length
+          const num = utils.distinctSubjectIds(statements).length
 
           if (options.onUpdate) options.onUpdate(num)
           totalProcessed += num
@@ -176,14 +173,7 @@ class BibsUpdater extends UpdaterBase {
     // Make sure stream-writing is configured
     if (streamName && schemaName) {
       // Get distinct bib ids: (should only be one..)
-      var distinctBibIds = Object.keys(
-        batch
-          .map((s) => s.subject_id)
-          .reduce((h, bnum) => {
-            h[bnum] = true
-            return h
-          }, {})
-      )
+      const distinctBibIds = utils.distinctSubjectIds(batch)
       // Submit bib ids to write stream:
       var recs = distinctBibIds.map((uri) => {
         return { type: 'record', uri }

--- a/lib/items-updater.js
+++ b/lib/items-updater.js
@@ -105,10 +105,7 @@ class ItemsUpdater extends UpdaterBase {
         .map((statements) => {
           // Report on success
           // Get distinct subject_ids:
-          var num = Object.keys(statements.reduce((h, statement) => {
-            h[statement.subject_id] = true
-            return h
-          }, {})).length
+          const num = utils.distinctSubjectIds(statements).length
 
           if (options.onUpdate) options.onUpdate(num)
           totalProcessed += num

--- a/lib/updater-base.js
+++ b/lib/updater-base.js
@@ -5,9 +5,20 @@ class UpdaterBase {
   constructor () {
     this.streamsClient = new NyplStreamsClient({ nyplDataApiClientBase: process.env['NYPL_API_BASE_URL'], logLevel: 'error' })
   }
+
 // this function should resolve until FailedRecordCount is zero
   _writeToStreamsClient (streamName, records, schemaName) {
     return this.streamsClient.write(streamName, records, { avroSchemaName: schemaName })
+          .then((response) => {
+            // FIXME This is a temporary hack to reset the log-level on loglevel back
+            // to the environment specified LOGLEVEL to overcome a bug in the current
+            // streaming client (the bug is actually in the deprecated version of
+            // data-api-client it includes). Fix for streamin-client is here:
+            // https://github.com/NYPL-discovery/node-nypl-streams-client/pull/4
+            // In the meatime, this should paper over the problem:
+            log.setLevel(process.env['LOGLEVEL'] || 'info')
+            return response
+          })
           .then((response) => {
             if (response.FailedRecordCount > 0) {
               var responseRecords = response.Records
@@ -19,7 +30,7 @@ class UpdaterBase {
               }
               return this._writeToStreamsClient(streamName, failedRecords, schemaName)
             }
-            log.info('Finished writing to stream. Records - ' + response.Records.length)
+            log.info(`UpdaterBase: Finished writing ${response.Records.length} record(s) to ${streamName}`)
             return Promise.resolve(response)
           })
           .catch((error) => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -121,4 +121,42 @@ const coreObjectsMappingByCode = (mapping, code) => {
     .shift()
 }
 
-module.exports = { readJson, capitalize, writeFile, flattenArray, lpad, lineCount, compact, groupBy, coreObjectsMappingByCode, truncate }
+/**
+ * Given a subjectId (e.g. "b1234", "b1234#1.001"), returns the same subjectId
+ * without any "internal" blanknode suffix.
+ *
+ * @param {string} subjectId - A subject id
+ *
+ * @returns {string} The id without any '#' suffix
+ *
+ * @example
+ * // The following returns "b1234"
+ * baseSubjectId("b1234#1.001")
+ */
+const baseSubjectId = (subjectId) => {
+  return subjectId.replace(/#.*$/, '')
+}
+
+/**
+ * Simple implementation of distinct.
+ *
+ * Beware: Uses Object.keys, so result is string[] regardless of input.
+ */
+const distinctStrings = (a) => Object.keys(a.reduce((m, i) => Object.assign(m, { [i]: true }), {}))
+
+/**
+ * Given an array of Statement instances, returns the distinct subject_ids
+ *
+ * @param {Array<Statement>} statements - An array of Statement instances
+ *
+ * @returns {Array<string>} An array of distinct subject_ids
+ */
+const distinctSubjectIds = (statements) => {
+  return distinctStrings(
+    statements
+      .map((s) => s.subject_id)
+      .map(baseSubjectId)
+  )
+}
+
+module.exports = { readJson, capitalize, writeFile, flattenArray, lpad, lineCount, compact, groupBy, coreObjectsMappingByCode, truncate, baseSubjectId, distinctSubjectIds }

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
     "mocha": "^3.5.0",
     "node-lambda": "^0.11.3",
     "sinon": "^4.0.1",
-    "standard": "6.0.8"
+    "standard": "^6.0.8"
   },
   "scripts": {
-    "test": "standard && mocha",
+    "test": "./node_modules/.bin/standard --env mocha && ./node_modules/.bin/mocha",
     "invoke:remote": "aws lambda invoke --function-name discoveryStorePoster --payload file://event.json --log-type Tail invoked.json | jq -r '.LogResult' | base64 --decode && rm invoked.json",
     "deploy-production": "./node_modules/.bin/node-lambda deploy -e production -f ./config/production.env -b subnet-59bcdd03,subnet-5deecd15 -g sg-116eeb60 --role arn:aws:iam::946183545209:role/lambda-full-access --profile nypl-digital-dev -S config/event-sources-production.json",
     "deploy-qa": "./node_modules/.bin/node-lambda deploy -e qa -f ./config/qa.env -b subnet-f4fe56af -g sg-1d544067 --role arn:aws:iam::224280085904:role/lambda_basic_execution --profile nypl-sandbox -S config/event-sources-qa.json",

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,16 @@
+const Statement = require('../lib/models/statement')
+const utils = require('../lib/utils')
+const expect = require('chai').expect
+
+describe('Utils', function () {
+  describe('distinctSubjectIds', function () {
+    it('returns distinct subjectIds', function () {
+      // Build an array of Statement instances from some subject_ids:
+      const statements = ['b100', 'b200', 'b300', 'b300', 'b100#1.0001']
+        .map((bnum) => new Statement({ subject_id: bnum, predicate: 'fake:pred', object_id: 'fake:objectid' }))
+      const output = utils.distinctSubjectIds(statements)
+      expect(output).to.be.a('array')
+      expect(output).to.have.members(['b100', 'b200', 'b300'])
+    })
+  })
+})


### PR DESCRIPTION
This includes the following fixes:
 - Adds a low risk hack to overcome a small bug in the deprecated
   version of the data-api-client presently included in streams-client,
   which overrides loglevel. The hack is to merely re-call setLevel
   using process.env.LOG_LEVEL after the offending data-api-client call.
 - Addresses the issue where IndexDocumentQueue receives blanknode
   subjectids (e.g. b100#1.0001') in addition to primary subjectids,
   which is *probably* harmless, but adds noise. Solution is a central
   function distinctSubjectIds for extracting distinct ids without
   suffixes.
 - Adds Utils tests
 - Changes standard & mocha path to node_modules folder; they were
   erroneously global before.