### PR TITLE
Patch parallel field bug

### DIFF
--- a/lib/serializers/bib.js
+++ b/lib/serializers/bib.js
@@ -346,7 +346,7 @@ var fromMarcJson = (object, datasource) => {
           if (parallelValues && parallelValues.length > 0) {
             parallelValues.forEach((parallelValue) => {
               let sourceRecordPath = `880[$u^=${path.isParallelFor}] ${path.subfields.map((subfield) => `$${subfield}`).join(' ')}`
-              builder.add(fieldMapping.pred, { literal: parallelValue }, null, { path: sourceRecordPath })
+              builder.add(fieldMapping.pred, { literal: parallelValue || ' ' }, null, { path: sourceRecordPath })
             })
           }
         })


### PR DESCRIPTION
This is a temporary hack to ensure that parallel values are saved as single space character if they are null. Normally the serializer would not attempt to save an empty statement, but it's sometimes required when saving parallel values in order to maintain index-association with parallel counterparts. This method should be retired when one of two decisions is made:

 1) We decide we do not care to link parallel values to their counterparts (i.e. contrary to webpac, we decide to list parallel values separately from their counterparts, making it unclear what which is an alternate expression of which.) In that case we can add `if (parallelValue) ..` here https://github.com/NYPL-discovery/discovery-store-poster/blob/master/lib/serializers/bib.js#L349 to skip adding the statement when parallelValue is `null`
 2) We decide to formally link parallel values to their counterparts via a numeric property or other identifier.

Discussion here https://jira.nypl.org/browse/SCC-509