### PR TITLE
Add Standard Number extraction

### DIFF
--- a/lib/serializers/bib.js
+++ b/lib/serializers/bib.js
@@ -207,6 +207,33 @@ var fromMarcJson = (object, datasource) => {
       })
     })
 
+    // Notes
+    var index = 0
+    var noteMapping = fieldMapper.getMapping('Note')
+    noteMapping.paths.forEach((path) => {
+      // Extract value by marc & subfields
+      var val = object.varField(path.marc, path.subfields, { preFilter: (block) => {
+        // Notes should be suppressed if ind1 is '0'
+        return block.ind1 !== '0'
+      }})
+
+      // Build provo path
+      var recordPath = path.marc
+      if (path.subfields) recordPath += ' ' + path.subfields.map((s) => `$${s}`).join(' ')
+
+      // Save one statement per value found:
+      val.forEach((v) => {
+        // Build a "Note" blank node with three statements:
+        let blankNode = {
+          'rdf:type': { id: 'bf:Note' },
+          'bf:noteType': { literal: path.description },
+          'rdfs:label': { literal: v }
+        }
+        builder.addBlankNode(noteMapping.pred, blankNode, index, { path: recordPath })
+        index += 1
+      })
+    })
+
     // Parse a bunch of straightforward identifiers:
     ; ['ISBN', 'ISSN', 'LCCN'].forEach((name) => {
       // Get mapping by name:
@@ -278,7 +305,7 @@ var fromMarcJson = (object, datasource) => {
           }
 
           // Save one statement per value found:
-          val.forEach((id) => {
+          val.forEach((id, index) => {
             let blankNode = {
               'rdf:type': { id: type },
               'rdf:value': { literal: id },
@@ -287,33 +314,6 @@ var fromMarcJson = (object, datasource) => {
             builder.addBlankNode(fieldMapping.pred, blankNode, index, { path: recordPath })
           })
         })
-      })
-    })
-
-    // Notes
-    var index = 0
-    var noteMapping = fieldMapper.getMapping('Note')
-    noteMapping.paths.forEach((path) => {
-      // Extract value by marc & subfields
-      var val = object.varField(path.marc, path.subfields, { preFilter: (block) => {
-        // Notes should be suppressed if ind1 is '0'
-        return block.ind1 !== '0'
-      }})
-
-      // Build provo path
-      var recordPath = path.marc
-      if (path.subfields) recordPath += ' ' + path.subfields.map((s) => `$${s}`).join(' ')
-
-      // Save one statement per value found:
-      val.forEach((v) => {
-        // Build a "Note" blank node with three statements:
-        let blankNode = {
-          'rdf:type': { id: 'bf:Note' },
-          'bf:noteType': { literal: path.description },
-          'rdfs:label': { literal: v }
-        }
-        builder.addBlankNode(noteMapping.pred, blankNode, index, { path: recordPath })
-        index += 1
       })
     })
 

--- a/lib/serializers/bib.js
+++ b/lib/serializers/bib.js
@@ -227,6 +227,26 @@ var fromMarcJson = (object, datasource) => {
       })
     })
 
+    // Parse a bunch of un-typed identifiers.
+    // These are "Standard numbers" in Sierra parlance, which include
+    // identifiers for different domains and classifications, which
+    // we'd like to store and index, but for which we don't have a
+    // rdf:type yet.
+    var fieldMapping = fieldMapper.getMapping('Identifier')
+    fieldMapping.paths.forEach((path) => {
+      // Extract value by marc & subfields
+      var val = object.varField(path.marc, path.subfields)
+
+      // Build provo path
+      var recordPath = path.marc
+      if (path.subfields) recordPath += ' ' + path.subfields.map((s) => `$${s}`).join(' ')
+
+      // Save one statement per value found:
+      val.forEach((id) => {
+        builder.add(fieldMapping.pred, { id }, null, { path: recordPath })
+      })
+    })
+
     // Notes
     var index = 0
     var noteMapping = fieldMapper.getMapping('Note')

--- a/lib/serializers/bib.js
+++ b/lib/serializers/bib.js
@@ -227,7 +227,7 @@ var fromMarcJson = (object, datasource) => {
       })
     })
 
-    // Parse a bunch of un-typed identifiers.
+    // Parse a bunch of generic bf:Identifier typed identifiers.
     // These are "Standard numbers" in Sierra parlance, which include
     // identifiers for different domains and classifications, which
     // we'd like to store and index, but for which we don't have a
@@ -243,7 +243,50 @@ var fromMarcJson = (object, datasource) => {
 
       // Save one statement per value found:
       val.forEach((id) => {
-        builder.add(fieldMapping.pred, { id }, null, { path: recordPath })
+        const type = 'bf:Identifier'
+        builder.add(fieldMapping.pred, { id, type }, null, { path: recordPath })
+      })
+    })
+
+    // Handle some cancelled/invalid identifier mappings:
+    ; [ 'ISBN (Canceled/Invalid)', 'ISSN (Canceled)', 'ISSN (Incorrect)' ].forEach((mappingName) => {
+      fieldMapper.getMapping(mappingName, (fieldMapping) => {
+        fieldMapping.paths.forEach((path) => {
+          // Extract value by marc & subfields
+          var val = object.varField(path.marc, path.subfields)
+
+          // Build provo path
+          var recordPath = path.marc
+          if (path.subfields) recordPath += ' ' + path.subfields.map((s) => `$${s}`).join(' ')
+
+          let type = null
+          let identifierStatus = null
+          // Determine type and identifierStatus based on mapping:
+          switch (mappingName) {
+            case 'ISBN (Canceled/Invalid)':
+              type = 'bf:Isbn'
+              identifierStatus = 'canceled/invalid'
+              break
+            case 'ISSN (Canceled)':
+              type = 'bf:Issn'
+              identifierStatus = 'canceled'
+              break
+            case 'ISSN (Incorrect)':
+              type = 'bf:Issn'
+              identifierStatus = 'incorrect'
+              break
+          }
+
+          // Save one statement per value found:
+          val.forEach((id) => {
+            let blankNode = {
+              'rdf:type': { id: type },
+              'rdf:value': { literal: id },
+              'bf:identifierStatus': { literal: identifierStatus }
+            }
+            builder.addBlankNode(fieldMapping.pred, blankNode, index, { path: recordPath })
+          })
+        })
       })
     })
 

--- a/test/bib-marc-test.js
+++ b/test/bib-marc-test.js
@@ -1014,4 +1014,35 @@ describe('Bib Marc Mapping', function () {
         })
     })
   })
+
+  describe('Un-typed Identifier extraction', function () {
+    it('should extract un-typed identifiers', function () {
+      var bib = BibSierraRecord.from(require('./data/bib-12082323.json'))
+
+      return bibSerializer.fromMarcJson(bib)
+        .then((statements) => new Bib(statements))
+        .then((bib) => {
+          const identifierStatements = bib.statements('dcterms:identifier')
+          assert(identifierStatements.length)
+          assert.equal(identifierStatements.length, 17)
+
+          const untypedIdentifiers = identifierStatements
+            .filter((statement) => !statement.object_type)
+            .map((statement) => statement.object_id)
+
+          assert.equal(untypedIdentifiers.length, 6)
+
+          ; [
+            'ISBN -- 020 $z',
+            'GPO Item number. -- 074',
+            'Sudoc no.  -- 086',
+            'Standard number (old RLIN, etc.) -- 035',
+            'Publisher no. -- 028 02  ',
+            'Report number. -- 027'
+          ].forEach((identifier) => {
+            assert(untypedIdentifiers.indexOf(identifier) >= 0)
+          })
+        })
+    })
+  })
 })

--- a/test/bib-marc-test.js
+++ b/test/bib-marc-test.js
@@ -74,7 +74,6 @@ describe('Bib Marc Mapping', function () {
       return bibSerializer.fromMarcJson(bib)
         .then((statements) => new Bib(statements))
         .then((bib) => {
-          console.log(bib.statements('bf:supplementaryContent'))
           assert(bib.statement('bf:supplementaryContent'))
           assert.equal(bib.literals('bf:supplementaryContent')[1], 'http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/')
           assert.equal(bib.literals('bf:supplementaryContent')[2], 'http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/')
@@ -1015,8 +1014,52 @@ describe('Bib Marc Mapping', function () {
     })
   })
 
-  describe('Un-typed Identifier extraction', function () {
-    it('should extract un-typed identifiers', function () {
+  describe('Canceled/Invalid identifier extraction', function () {
+    it('should extract Canceled ISBNs', function () {
+      var bib = BibSierraRecord.from(require('./data/bib-12082323.json'))
+
+      return bibSerializer.fromMarcJson(bib)
+        .then((statements) => new Bib(statements))
+        .then((bib) => {
+          const identifierBlankNodes = bib.blankNodes('dcterms:identifier')
+          assert(identifierBlankNodes.length)
+          assert.equal(identifierBlankNodes.length, 1)
+
+          const isbnNodes = identifierBlankNodes
+            .filter((node) => {
+              return node.objectId('rdf:type') === 'bf:Isbn' &&
+                node.literal('bf:identifierStatus') === 'canceled/invalid'
+            })
+
+          assert.equal(isbnNodes.length, 1)
+          assert.equal(isbnNodes[0].literal('value', 'ISBN -- 020 $z'))
+        })
+    })
+
+    it('should extract ISSN (Incorrect)', function () {
+      var bib = BibSierraRecord.from(require('./data/bib-10384239.json'))
+
+      return bibSerializer.fromMarcJson(bib)
+        .then((statements) => new Bib(statements))
+        .then((bib) => {
+          const identifierBlankNodes = bib.blankNodes('dcterms:identifier')
+          assert(identifierBlankNodes.length)
+          assert.equal(identifierBlankNodes.length, 1)
+
+          const isbnNodes = identifierBlankNodes
+            .filter((node) => {
+              return node.objectId('rdf:type') === 'bf:Issn' &&
+                node.literal('bf:identifierStatus') === 'incorrect'
+            })
+
+          assert.equal(isbnNodes.length, 1)
+          assert.equal(isbnNodes[0].literal('value', '0018-4365'))
+        })
+    })
+  })
+
+  describe('Generic Identifier extraction', function () {
+    it('should extract generic typed identifiers', function () {
       var bib = BibSierraRecord.from(require('./data/bib-12082323.json'))
 
       return bibSerializer.fromMarcJson(bib)
@@ -1026,21 +1069,20 @@ describe('Bib Marc Mapping', function () {
           assert(identifierStatements.length)
           assert.equal(identifierStatements.length, 17)
 
-          const untypedIdentifiers = identifierStatements
-            .filter((statement) => !statement.object_type)
+          const genericIdentifiers = identifierStatements
+            .filter((statement) => statement.object_type === 'bf:Identifier')
             .map((statement) => statement.object_id)
 
-          assert.equal(untypedIdentifiers.length, 6)
+          assert.equal(genericIdentifiers.length, 5)
 
           ; [
-            'ISBN -- 020 $z',
             'GPO Item number. -- 074',
             'Sudoc no.  -- 086',
             'Standard number (old RLIN, etc.) -- 035',
             'Publisher no. -- 028 02  ',
             'Report number. -- 027'
           ].forEach((identifier) => {
-            assert(untypedIdentifiers.indexOf(identifier) >= 0)
+            assert(genericIdentifiers.indexOf(identifier) >= 0)
           })
         })
     })

--- a/test/data/bib-10384239.json
+++ b/test/data/bib-10384239.json
@@ -1,0 +1,635 @@
+{
+  "id": "10384239",
+  "nyplSource": "sierra-nypl",
+  "nyplType": "bib",
+  "updatedDate": "2012-03-08T23:19:32-05:00",
+  "createdDate": "2008-12-13T22:29:11-05:00",
+  "deletedDate": null,
+  "deleted": false,
+  "locations": [
+    {
+      "code": "slr",
+      "name": "SIBL - Science Industry and Business"
+    }
+  ],
+  "suppressed": false,
+  "lang": {
+    "code": "fre",
+    "name": "French"
+  },
+  "title": "Hommes et migrations. études.",
+  "author": "",
+  "materialType": {
+    "code": "a",
+    "value": "BOOK/TEXT"
+  },
+  "bibLevel": {
+    "code": "s",
+    "value": "SERIAL"
+  },
+  "publishYear": 1966,
+  "catalogDate": "1999-07-14",
+  "country": {
+    "code": "fr ",
+    "name": "France"
+  },
+  "normTitle": "hommes et migrations études",
+  "normAuthor": "",
+  "standardNumbers": [],
+  "controlNumber": "NYPG764472191-S",
+  "fixedFields": {
+    "24": {
+      "label": "Language",
+      "value": "fre",
+      "display": "French"
+    },
+    "25": {
+      "label": "Skip",
+      "value": "0",
+      "display": null
+    },
+    "26": {
+      "label": "Location",
+      "value": "slr  ",
+      "display": "SIBL - Science Industry and Business"
+    },
+    "27": {
+      "label": "COPIES",
+      "value": "2",
+      "display": null
+    },
+    "28": {
+      "label": "Cat. Date",
+      "value": "1999-07-14",
+      "display": null
+    },
+    "29": {
+      "label": "Bib Level",
+      "value": "s",
+      "display": "SERIAL"
+    },
+    "30": {
+      "label": "Material Type",
+      "value": "a",
+      "display": "BOOK/TEXT"
+    },
+    "31": {
+      "label": "Bib Code 3",
+      "value": "-",
+      "display": null
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "b",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "10384239",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": "2008-12-13T22:29:11Z",
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2012-03-08T23:19:32Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": "6",
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "1",
+      "display": null
+    },
+    "89": {
+      "label": "Country",
+      "value": "fr ",
+      "display": "France"
+    },
+    "98": {
+      "label": "PDATE",
+      "value": "2011-10-20T00:58:31Z",
+      "display": null
+    },
+    "107": {
+      "label": "MARC Type",
+      "value": " ",
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "fieldTag": "b",
+      "marcTag": "710",
+      "ind1": "2",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Etudes sociales nord-africaines (Association)"
+        }
+      ]
+    },
+    {
+      "fieldTag": "c",
+      "marcTag": "852",
+      "ind1": "8",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "h",
+          "content": "JLK 75-318"
+        },
+        {
+          "tag": "z",
+          "content": "Library has: Library has: no 104, 110-122; published 1966, 1968-1975."
+        },
+        {
+          "tag": "z",
+          "content": "Library has: No. 104 in C-14-50."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Emigration and immigration"
+        },
+        {
+          "tag": "v",
+          "content": "Periodicals."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "651",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "France"
+        },
+        {
+          "tag": "x",
+          "content": "Emigration and immigration"
+        },
+        {
+          "tag": "v",
+          "content": "Periodicals."
+        }
+      ]
+    },
+    {
+      "fieldTag": "i",
+      "marcTag": "022",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "0223-3304"
+        },
+        {
+          "tag": "y",
+          "content": "0018-4365"
+        }
+      ]
+    },
+    {
+      "fieldTag": "l",
+      "marcTag": "010",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "sn 85005895"
+        }
+      ]
+    },
+    {
+      "fieldTag": "l",
+      "marcTag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "RCON-EPA"
+        }
+      ]
+    },
+    {
+      "fieldTag": "l",
+      "marcTag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "(WaOLN)nyp0387785"
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "510",
+      "ind1": "2",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "International labour documentation"
+        },
+        {
+          "tag": "x",
+          "content": "0020-7756"
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "580",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "For earlier file whose numbering it continues, see: Études sociales nord-africains (Association). Cahiers nord-africains."
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "590",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Ceased publication."
+        }
+      ]
+    },
+    {
+      "fieldTag": "o",
+      "marcTag": "001",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "NYPG764472191-S",
+      "subfields": null
+    },
+    {
+      "fieldTag": "p",
+      "marcTag": "260",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Paris,"
+        },
+        {
+          "tag": "b",
+          "content": "Études sociales nord-africaines,"
+        },
+        {
+          "tag": "c",
+          "content": "1968-1978."
+        }
+      ]
+    },
+    {
+      "fieldTag": "q",
+      "marcTag": "852",
+      "ind1": "8",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "h",
+          "content": "JLK 75-318"
+        },
+        {
+          "tag": "z",
+          "content": "Library has: Library has: no 104, 110-122; published 1966, 1968-1975."
+        },
+        {
+          "tag": "z",
+          "content": "Library has: No. 104 in C-14-50."
+        }
+      ]
+    },
+    {
+      "fieldTag": "r",
+      "marcTag": "300",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "21 v."
+        },
+        {
+          "tag": "b",
+          "content": "ill."
+        },
+        {
+          "tag": "c",
+          "content": "20 cm."
+        }
+      ]
+    },
+    {
+      "fieldTag": "r",
+      "marcTag": "310",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Annual"
+        }
+      ]
+    },
+    {
+      "fieldTag": "r",
+      "marcTag": "362",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "no 104-124."
+        }
+      ]
+    },
+    {
+      "fieldTag": "t",
+      "marcTag": "245",
+      "ind1": "0",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Hommes et migrations."
+        },
+        {
+          "tag": "p",
+          "content": "études."
+        }
+      ]
+    },
+    {
+      "fieldTag": "u",
+      "marcTag": "210",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Hommes migr., Étud."
+        }
+      ]
+    },
+    {
+      "fieldTag": "u",
+      "marcTag": "299",
+      "ind1": "0",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Hommes et migrations."
+        },
+        {
+          "tag": "p",
+          "content": "études."
+        }
+      ]
+    },
+    {
+      "fieldTag": "v",
+      "marcTag": "959",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": ".b13928260"
+        },
+        {
+          "tag": "b",
+          "content": "09-07-07"
+        },
+        {
+          "tag": "c",
+          "content": "08-05-91"
+        }
+      ]
+    },
+    {
+      "fieldTag": "x",
+      "marcTag": "780",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "t",
+          "content": "Cahiers nord-africains"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "003",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "CStRLIN",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "005",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "19990702085825.6",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "008",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "760629d19661978fr arz        0   b0fre dcas   ",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "040",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "MnMULS"
+        },
+        {
+          "tag": "c",
+          "content": "MnMULS"
+        },
+        {
+          "tag": "d",
+          "content": "NIC"
+        },
+        {
+          "tag": "d",
+          "content": "AIP"
+        },
+        {
+          "tag": "d",
+          "content": "NSDP"
+        },
+        {
+          "tag": "d",
+          "content": "DLC"
+        },
+        {
+          "tag": "d",
+          "content": "CU"
+        },
+        {
+          "tag": "d",
+          "content": "NN"
+        },
+        {
+          "tag": "d",
+          "content": "WaOLN"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "042",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "nsdp"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "043",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "e-fr---"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "997",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "b"
+        },
+        {
+          "tag": "b",
+          "content": "07-14-99"
+        },
+        {
+          "tag": "c",
+          "content": "s"
+        },
+        {
+          "tag": "d",
+          "content": "a"
+        },
+        {
+          "tag": "e",
+          "content": "-"
+        },
+        {
+          "tag": "f",
+          "content": "fre"
+        },
+        {
+          "tag": "g",
+          "content": "fr "
+        },
+        {
+          "tag": "h",
+          "content": "0"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "222",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Hommes et migrations. Études"
+        }
+      ]
+    },
+    {
+      "fieldTag": "_",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "00000cas  2200373   4500",
+      "subfields": null
+    }
+  ]
+}


### PR DESCRIPTION
Amends bib serializer to extract "Standard Numbers", which have been
implmented as plain dcterms:identifier statements with no `object_type`
(i.e. no rdf:type). This is intentional as we don't have a type for them
and in some cases we know they're values are
"Invalid"/"Canceled"/"Incorrect" based on where we extracted them from
the sierra record.

Depends on an unreleased nypl-core version, which can be accessed by
setting NYPL_CORE_VERSION=pb/add-remaining-identifiers

https://jira.nypl.org/browse/SCC-1224