### PR TITLE
SCC-2235/SCC-2236 Update Call Number parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,13 @@ deploy:
    script: ./scripts/travis-deploy.sh $TRAVIS_BRANCH
    on:
      all_branches: true
-     condition: $TRAVIS_BRANCH =~ ^(development|qa|production)$
+     condition: $TRAVIS_BRANCH =~ ^(qa|production)$
  - provider: script
    script: ./node_modules/.bin/node-lambda package -e "$TRAVIS_BRANCH"
    skip_cleanup: true
    on:
      all_branches: true
-     condition: $TRAVIS_BRANCH =~ ^(development|qa|production)$
+     condition: $TRAVIS_BRANCH =~ ^(qa|production)$
  - provider: s3
    access_key_id: "${!AWS_KEY_VAR}"
    secret_access_key: "${!AWS_SECRET_VAR}"
@@ -33,7 +33,7 @@ deploy:
    local_dir: build
    on:
      all_branches: true
-     condition: $TRAVIS_BRANCH =~ ^(development|qa|production)$
+     condition: $TRAVIS_BRANCH =~ ^(qa|production)$
 after_deploy: echo "Successfully executed deploy trigger for $TRAVIS_BRANCH"
 env:
   global:

--- a/lib/serializers/item.js
+++ b/lib/serializers/item.js
@@ -134,9 +134,12 @@ var fromMarcJson = (object, datasource) => {
     if (barcode) builder.add(fieldMapper.predicateFor('Identifier'), { id: barcode.value, type: 'bf:Barcode' }, 0, { path: barcode.path })
 
     // Callnum
-    var callnum = null
+    let callnum
     // First pull it from varfield:
-    if (object.varField('852', ['h'])) callnum = { value: object.varField('852', ['h'])[0], path: '852 $h' }
+    const shelfMarkMapping = fieldMapper.getMapping('Call number')
+    const shelfMarkMarc = shelfMarkMapping.paths[0].marc
+    const shelfMarkSubfields = shelfMarkMapping.paths[0].subfields
+    if (object.varField(shelfMarkMarc, ['h'])) callnum = { value: object.varField(shelfMarkMarc, shelfMarkSubfields)[0], path: shelfMarkSubfields.map((s) => `$${s}`).join(' ') }
     // If not found in var field
     if (!callnum || !callnum.value) callnum = { value: object.callNumber, path: 'callNumber' }
     // If not yet found, look in 945 $g
@@ -147,12 +150,20 @@ var fromMarcJson = (object, datasource) => {
 
     // If not found in var field
     if (callnum && callnum.value) {
+      // Store Physical Location before appending v fieldTag suffix
+      builder.add(fieldMapper.predicateFor('Physical Location'), { literal: callnum.value }, 0, { path: '852 $khinz' })
+
       // Pull callnumber suffix from fieldTag v if present
       var callnumSuffix = object.fieldTag('v')
       if (callnumSuffix && callnumSuffix.length) {
         callnum.value += ' ' + callnumSuffix[0]
         callnum.path += ', fieldTag v'
+
+        // Store this data in a standalone field
+        builder.add(fieldMapper.predicateFor('Enumeration Chronology'), { literal: callnumSuffix[0] }, 0, { path: 'fieldTag v' })
       }
+
+      // Finally store the complete shelfMark data
       builder.add(fieldMapper.predicateFor('Call number'), { literal: callnum.value }, 0, { path: callnum.path })
     }
 

--- a/test/data/item-33770493.json
+++ b/test/data/item-33770493.json
@@ -1,0 +1,233 @@
+{
+  "nyplSource": "sierra-nypl",
+  "bibIds": [
+    "20857278"
+  ],
+  "id": "33770493",
+  "nyplType": "item",
+  "updatedDate": "2018-10-11T19:05:46-04:00",
+  "createdDate": "2016-02-24T15:27:47-05:00",
+  "deletedDate": null,
+  "deleted": false,
+  "location": {
+    "code": "mall1",
+    "name": "SASB - General Research - Room 315"
+  },
+  "status": {
+    "code": "o",
+    "display": "USE IN LIBRARY",
+    "duedate": null
+  },
+  "barcode": "33433118059629",
+  "callNumber": "*R-RMRR PR451 .E553 2015",
+  "itemType": null,
+  "fixedFields": {
+    "57": {
+      "label": "BIB HOLD",
+      "value": "false",
+      "display": null
+    },
+    "58": {
+      "label": "Copy No.",
+      "value": "1",
+      "display": null
+    },
+    "59": {
+      "label": "Item Code 1",
+      "value": "0",
+      "display": null
+    },
+    "60": {
+      "label": "Item Code 2",
+      "value": "-",
+      "display": null
+    },
+    "61": {
+      "label": "Item Type",
+      "value": "2",
+      "display": "book non-circ"
+    },
+    "62": {
+      "label": "Price",
+      "value": "0.000000",
+      "display": null
+    },
+    "64": {
+      "label": "Checkout Location",
+      "value": "0",
+      "display": null
+    },
+    "70": {
+      "label": "Checkin Location",
+      "value": "0",
+      "display": null
+    },
+    "74": {
+      "label": "Item Use 3",
+      "value": "0",
+      "display": null
+    },
+    "76": {
+      "label": "Total Checkouts",
+      "value": "0",
+      "display": null
+    },
+    "77": {
+      "label": "Total Renewals",
+      "value": "0",
+      "display": null
+    },
+    "79": {
+      "label": "Location",
+      "value": "mall1",
+      "display": "SASB - General Research - Room 315"
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "i",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "33770493",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": "2016-02-24T15:27:47Z",
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2018-10-11T19:05:46Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": "5",
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "1",
+      "display": null
+    },
+    "88": {
+      "label": "Status",
+      "value": "o",
+      "display": "USE IN LIBRARY"
+    },
+    "93": {
+      "label": "Inhouse Use",
+      "value": "0",
+      "display": null
+    },
+    "94": {
+      "label": "Copy Use",
+      "value": "0",
+      "display": null
+    },
+    "97": {
+      "label": "Item Message",
+      "value": "-",
+      "display": null
+    },
+    "98": {
+      "label": "PDATE",
+      "value": "2017-01-16T15:57:32Z",
+      "display": null
+    },
+    "108": {
+      "label": "OPAC Message",
+      "value": "-",
+      "display": null
+    },
+    "109": {
+      "label": "Year-to-Date Circ",
+      "value": "0",
+      "display": null
+    },
+    "110": {
+      "label": "Last Year Circ",
+      "value": "0",
+      "display": null
+    },
+    "127": {
+      "label": "Item Agency",
+      "value": "33",
+      "display": "S.A. Schwarzman Bldg."
+    },
+    "161": {
+      "label": "VI Central",
+      "value": "0",
+      "display": null
+    },
+    "162": {
+      "label": "IR Dist Learn Same Site",
+      "value": "0",
+      "display": null
+    },
+    "264": {
+      "label": "Holdings Item Tag",
+      "value": "6",
+      "display": null
+    },
+    "265": {
+      "label": "Inherit Location",
+      "value": "false",
+      "display": null
+    },
+    "306": {
+      "label": "Sticky Status",
+      "value": " ",
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "fieldTag": "b",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "33433118059629",
+      "subfields": null
+    },
+    {
+      "fieldTag": "c",
+      "marcTag": "852",
+      "ind1": "0",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "k",
+          "content": "*R-RMRR"
+        },
+        {
+          "tag": "h",
+          "content": "PR451"
+        },
+        {
+          "tag": "i",
+          "content": ".E553 2015"
+        }
+      ]
+    },
+    {
+      "fieldTag": "t",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "CATRL/mnm",
+      "subfields": null
+    },
+    {
+      "fieldTag": "v",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "v. 3",
+      "subfields": null
+    }
+  ]
+}

--- a/test/item-marc-test.js
+++ b/test/item-marc-test.js
@@ -72,6 +72,8 @@ describe('Item Marc Mapping', function () {
           assert.equal(item.objectId('nypl:holdingLocation'), 'loc:rc2sl')
           // Yeah i guess that's the actual call number?
           assert.equal(item.literal('nypl:shelfMark'), 'TPB (International Railway Congress. (VII) Washington, 1905. Summary of proceedings) v. 2')
+          assert.equal(item.literal('bf:physicalLocation'), 'TPB (International Railway Congress. (VII) Washington, 1905. Summary of proceedings)')
+          assert.equal(item.literal('bf:enumerationAndChronology'), 'v. 2')
           assert.equal(item.objectId('nypl:catalogItemType'), 'catalogItemType:66')
           assert.equal(item.objectId('nypl:bnum'), 'urn:bnum:b13689507')
         })
@@ -319,6 +321,25 @@ describe('Item Marc Mapping', function () {
             delete require.cache[require.resolve('./data/item-10003973.json')]
           })
       }))
+    })
+  })
+
+  describe('Complex Call Number Formatting', function () {
+    it('should add call number prefix and suffixes', function () {
+      const item = ItemSierraRecord.from(require('./data/item-33770493.json'))
+
+      return itemSerializer.fromMarcJson(item)
+        .then((statements) => new Item(statements))
+        .then((item) => {
+          assert.equal(item.objectId('rdfs:type'), 'bf:Item')
+          assert.equal(item.objectId('nypl:owner'), 'orgs:1101')
+          assert.equal(item.objectId('nypl:holdingLocation'), 'loc:mall1')
+          // Yeah i guess that's the actual call number?
+          assert.equal(item.literal('nypl:shelfMark'), '*R-RMRR PR451 .E553 2015 v. 3')
+          assert.equal(item.literal('bf:physicalLocation'), '*R-RMRR PR451 .E553 2015')
+          assert.equal(item.literal('bf:enumerationAndChronology'), 'v. 3')
+          assert.equal(item.objectId('nypl:bnum'), 'urn:bnum:b20857278')
+        })
     })
   })
 })


### PR DESCRIPTION
This implements two updates for the Call Number parsing for items

1) It incorporates the additional `k` and `i` prefix and suffix `852` subfields that are present in the classic catalog
2) Adds to additional fields related to the call number that are used in new SCC designs. These contain subsets of the fields that are present in the `shelfMark`. `physicalLocation` contains the stem of the `shelfMark` and will be used to display the Call Number in the SCC items table. The `chronologyAndEnumeration` contains the coverage of the item and is displayed in that column in the table. This should enable some new features.