### PR TITLE
SCC-2207 Bug fixes for holdings records

### DIFF
--- a/lib/holdings-updater.js
+++ b/lib/holdings-updater.js
@@ -134,9 +134,13 @@ class HoldingsUpdater extends UpdaterBase {
   _getBibIdsForHoldingStatements (statements) {
     // Build hash mapping subject_ids to bibId or null:
     const subjectIdsToBibIds = statements.reduce((hash, statement) => {
-      if (statement.predicate === 'nypl:bnum') hash[statement.subject_id] = statement.object_id.replace('urn:bnum:', '')
-      else if (!Object.keys(hash).includes(statement.subject_id)) hash[statement.subject_id] = null
-    })
+      if (statement.predicate === 'nypl:bnum') {
+        hash[statement.subject_id] = statement.object_id.replace('urn:bnum:', '')
+      } else if (!Object.keys(hash).includes(statement.subject_id) && !statement.subject_id.includes('#')) {
+        hash[statement.subject_id] = null
+      }
+      return hash
+    }, {})
 
     // Since some of those bibIds will be null (holding deletion), map our bibIds
     // to an array of Promises that fill in missing bibIds via db lookup:

--- a/lib/serializers/holding.js
+++ b/lib/serializers/holding.js
@@ -12,7 +12,7 @@ const fromMarcJson = (object) => {
   try {
     const fieldMapper = buildFieldMapper('holding', null)
 
-    const holdingId = object.prefixedId
+    const holdingId = object.prefixedId()
 
     const datasource = Datasource.byMarcJsonNyplSource('sierra-nypl')
 


### PR DESCRIPTION
Local testing revealed several minor, but import fixes to the new holding records parsers. They are:

- There was a missing set of parentheses on the `prefixedId` method call for holdings
- The `reduce` function in `_getBibForHoldingStatements` was missing the initial object
- Adding a missing return from the above `reduce`
- Adding an additional check to make sure that blank nodes are not set for reindexing

NOTE: These fixes were made previously but were mistakenly omitted from the recent merge.