### PR TITLE
SCC-2271 Fix legacy i field holding parsing

### DIFF
--- a/lib/serializers/holding.js
+++ b/lib/serializers/holding.js
@@ -84,8 +84,8 @@ const fromMarcJson = (object) => {
     // Drawn from the 843$a field, or if not found there potentially in the i fieldTag
     if (object.varField('843', ['a']).length > 0) {
       builder.add(fieldMapper.predicateFor('Format'), { literal: object.varField('843', ['a'])[0] }, 0, { path: '843 $a' })
-    } else if (object.fieldTag('i')) {
-      builder.add(fieldMapper.predicateFor('Format'), { literal: object.fieldTag('i') }, 0, { path: 'fieldTag i' })
+    } else if (object.fieldTag('i') && object.fieldTag('i').length > 0) {
+      builder.add(fieldMapper.predicateFor('Format'), { literal: object.fieldTag('i')[0] }, 0, { path: 'fieldTag i' })
     }
 
     // Note

--- a/test/holding-marc-test.js
+++ b/test/holding-marc-test.js
@@ -35,9 +35,18 @@ describe('Holding Marc Mapping', () => {
         .then((holding) => {
           assert.equal(holding.objectId('rdfs:type'), 'nypl:Holding')
           assert.equal(holding.objectId('nypl:bnum'), 'urn:bnum:b14630864')
-          assert.equal(holding.literal('dcterms:format'), 'PRINT')
           assert.equal(holding.objectId('nypl:holdingLocation'), 'loc:mal')
           assert.equal(holding.literal('nypl:shelfMark'), 'JBM 00-489')
+        })
+    })
+
+    it('should extract format statements from legacy i fieldTag', () => {
+      const holding = HoldingSierraRecord.from(require('./data/holding-1082762.json'))
+
+      return holdingSerializer.fromMarcJson(holding)
+        .then((statements) => new Holding(statements))
+        .then((holding) => {
+          assert.strictEqual(holding.literal('dcterms:format'), 'PRINT')
         })
     })
 


### PR DESCRIPTION
The importing of the Format (e.g. "PRINT") from the holding record comes from the `i` field, either as a legacy field or from the MARC `843` field. When imported from the legacy field this was being set as an array. This simply corrects that issue and adds a new test.

This does not cause a fatal error but instead for many Format strings to appear in the front end as `{"PRINT"}` as they are stored as arrays in the PCDM.

This was not caught earlier because the `assert.equal` call evaluated `['PRINT']` and `PRINT` as equal. Adding the `assert.strictEqual` check instead raised the error. This should be carried forward for all new tests written.