### PR TITLE
HOTFIX Missing bib_ids for items and holdings

### DIFF
--- a/lib/holdings-updater.js
+++ b/lib/holdings-updater.js
@@ -150,7 +150,13 @@ class HoldingsUpdater extends UpdaterBase {
       else {
         // Otherwise look it up in the db:
         return db.getStatement('resource', subjectId, 'nypl:bnum')
-          .then((result) => result.object_id.replace('urn:bnum:', ''))
+          .then((result) => {
+            if(result) return result.object_id.replace('urn:bnum:', '')
+            else {
+              log.warn(`Skipping bib reindex for holding ${subjectId}, could not locate`)
+              return null
+            } 
+          })
       }
     })
 
@@ -170,7 +176,7 @@ class HoldingsUpdater extends UpdaterBase {
     if (streamName && schemaName) {
       this._getBibIdsForHoldingStatements(batch)
         .then((bibIds) => {
-          let kinesisRecords = bibIds.map((bibId) => {
+          let kinesisRecords = bibIds.filter((b) => b).map((bibId) => {
             return { type: 'record', uri: bibId }
           })
           return this._writeToStreamsClient(streamName, kinesisRecords, schemaName)

--- a/lib/holdings-updater.js
+++ b/lib/holdings-updater.js
@@ -151,11 +151,11 @@ class HoldingsUpdater extends UpdaterBase {
         // Otherwise look it up in the db:
         return db.getStatement('resource', subjectId, 'nypl:bnum')
           .then((result) => {
-            if(result) return result.object_id.replace('urn:bnum:', '')
+            if (result) return result.object_id.replace('urn:bnum:', '')
             else {
               log.warn(`Skipping bib reindex for holding ${subjectId}, could not locate`)
               return null
-            } 
+            }
           })
       }
     })

--- a/lib/items-updater.js
+++ b/lib/items-updater.js
@@ -159,7 +159,13 @@ class ItemsUpdater extends UpdaterBase {
       else {
         // Otherwise look it up in the db:
         return db.getStatement('resource', subjectId, 'nypl:bnum')
-          .then((result) => result.object_id.replace('urn:bnum:', ''))
+          .then((result) => {
+            if(result) return result.object_id.replace('urn:bnum:', '')
+            else {
+              log.warn(`Skipping bib reindex for item ${subjectId}, could not locate`)
+              return null
+            } 
+          })
       }
     })
 
@@ -179,7 +185,7 @@ class ItemsUpdater extends UpdaterBase {
     if (streamName && schemaName) {
       this._getBibIdsForItemStatements(batch)
         .then((bibIds) => {
-          let kinesisRecords = bibIds.map((bibId) => {
+          let kinesisRecords = bibIds.filter((b) => b).map((bibId) => {
             return { type: 'record', uri: bibId }
           })
           return this._writeToStreamsClient(streamName, kinesisRecords, schemaName)

--- a/lib/items-updater.js
+++ b/lib/items-updater.js
@@ -160,11 +160,11 @@ class ItemsUpdater extends UpdaterBase {
         // Otherwise look it up in the db:
         return db.getStatement('resource', subjectId, 'nypl:bnum')
           .then((result) => {
-            if(result) return result.object_id.replace('urn:bnum:', '')
+            if (result) return result.object_id.replace('urn:bnum:', '')
             else {
               log.warn(`Skipping bib reindex for item ${subjectId}, could not locate`)
               return null
-            } 
+            }
           })
       }
     })


### PR DESCRIPTION
This is a fix for a bug that has appeared that affects the lookup of `bib_ids` for `Item` and `Holding` records. It is still unclear what the root source of this is but it seems that there can be records that are pushed to the `discovery-store` for the first time without a `bib_id`, either due to a cataloging error or because the record was deleted already(?)

If this is true there is no need to re-index any bib records because as far as the store and api are concerned, no updates have taken place. The record should already not exist and can be safely skipped. I've added a warning so that these events are logged.

The only question is if there is a more fundamental reason for this issue that should be addressed at that level