### PR TITLE
Fix bug where e-resource with https: is skipped

### DIFF
--- a/lib/serializers/bib.js
+++ b/lib/serializers/bib.js
@@ -492,9 +492,10 @@ var extractElectronicResourcesFromBibMarc = (bib, type) => {
       // Consider all subfield values:
       var values = Object.keys(r).map((k) => r[k])
       // Get the one that looks like a URL
-      var url = values.filter((v) => v.indexOf('http:') === 0)[0]
+      const isUrl = (v) => /^https?:/.test(v)
+      var url = values.filter(isUrl)[0]
       // .. and choose the label from the longest value that isn't a URL
-      var label = values.filter((v) => v.indexOf('http:') !== 0).sort((e1, e2) => e1.length > e2.length ? -1 : 1)[0]
+      var label = values.filter((v) => !isUrl(v)).sort((e1, e2) => e1.length > e2.length ? -1 : 1)[0]
 
       return url ? { url, label, path: '856' } : null
     }).filter((r) => r)

--- a/test/bib-marc-test.js
+++ b/test/bib-marc-test.js
@@ -140,6 +140,16 @@ describe('Bib Marc Mapping', function () {
       assert.strictEqual(resources[3].label, undefined)
     })
 
+    it('should extract electronic resource representing aeon link', function () {
+      const bib = BibSierraRecord.from(require('./data/bib-10204814.json'))
+
+      const resources = bibSerializer.extractElectronicResourcesFromBibMarc(bib, 'ER')
+      assert.strictEqual(resources.length, 1)
+
+      assert.strictEqual(resources[0].url, 'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Something+concerning+Nobody.&Site=SASAR&CallNumber=Arents+S+0937&ItemPlace=London,&ItemPublisher=Printed+for+Robert+Scholey,&Date=1814.&Site=SASAR')
+      assert.strictEqual(resources[0].label, 'Request Access to Special Collections Material')
+    })
+
     it('should extract many core properties from a MICROFORM', function () {
       var bib = BibSierraRecord.from(require('./data/bib-19995767.json'))
 

--- a/test/data/bib-10204814.json
+++ b/test/data/bib-10204814.json
@@ -1,0 +1,484 @@
+{
+  "id": "10204814",
+  "nyplSource": "sierra-nypl",
+  "nyplType": "bib",
+  "updatedDate": "2021-02-08T13:29:00-05:00",
+  "createdDate": "2008-12-13T19:16:33-05:00",
+  "deletedDate": null,
+  "deleted": false,
+  "locations": [
+    {
+      "code": "mac",
+      "name": "SASB - Arents Collection Rm 328"
+    }
+  ],
+  "suppressed": false,
+  "lang": {
+    "code": "eng",
+    "name": "English"
+  },
+  "title": "Something concerning Nobody.",
+  "author": "",
+  "materialType": {
+    "code": "a",
+    "value": "BOOK/TEXT"
+  },
+  "bibLevel": {
+    "code": "m",
+    "value": "MONOGRAPH"
+  },
+  "publishYear": 1814,
+  "catalogDate": "2000-10-05",
+  "country": {
+    "code": "enk",
+    "name": "England"
+  },
+  "normTitle": "something concerning nobody",
+  "normAuthor": "",
+  "standardNumbers": [],
+  "controlNumber": "NYPG744852523-B",
+  "fixedFields": {
+    "24": {
+      "label": "Language",
+      "value": "eng",
+      "display": "English"
+    },
+    "25": {
+      "label": "Skip",
+      "value": "0",
+      "display": null
+    },
+    "26": {
+      "label": "Location",
+      "value": "mac  ",
+      "display": "SASB - Arents Collection Rm 328"
+    },
+    "27": {
+      "label": "COPIES",
+      "value": "1",
+      "display": null
+    },
+    "28": {
+      "label": "Cat. Date",
+      "value": "2000-10-05",
+      "display": null
+    },
+    "29": {
+      "label": "Bib Level",
+      "value": "m",
+      "display": "MONOGRAPH"
+    },
+    "30": {
+      "label": "Material Type",
+      "value": "a",
+      "display": "BOOK/TEXT"
+    },
+    "31": {
+      "label": "Bib Code 3",
+      "value": "-",
+      "display": null
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "b",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "10204814",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": "2008-12-13T19:16:33Z",
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2021-02-08T13:29:00Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": "6",
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "1",
+      "display": null
+    },
+    "89": {
+      "label": "Country",
+      "value": "enk",
+      "display": "England"
+    },
+    "98": {
+      "label": "PDATE",
+      "value": "2012-09-27T13:12:05Z",
+      "display": null
+    },
+    "107": {
+      "label": "MARC Type",
+      "value": " ",
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Scholey, Robert."
+        }
+      ]
+    },
+    {
+      "fieldTag": "c",
+      "marcTag": "852",
+      "ind1": "8",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "h",
+          "content": "Arents S 0937"
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Tobacco"
+        },
+        {
+          "tag": "v",
+          "content": "Humor."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Smoking in art."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Tobacco"
+        },
+        {
+          "tag": "v",
+          "content": "Poetry."
+        }
+      ]
+    },
+    {
+      "fieldTag": "l",
+      "marcTag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "NN744852523"
+        }
+      ]
+    },
+    {
+      "fieldTag": "l",
+      "marcTag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "(WaOLN)nyp0206500"
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "\"Nobody scents it\" (includes incident with a pipe-smoker): p. 24-28 and plate 5. Acrostic verse on \"Quid\": p. 44. \"Hollandia: Behold Dutch biped ... fond of naught so much as smoking\" (poem): p. 109."
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Provenance: Graham M. Adee (bookplate); The Brook (bookplate)."
+        }
+      ]
+    },
+    {
+      "fieldTag": "o",
+      "marcTag": "001",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "NYPG744852523-B",
+      "subfields": null
+    },
+    {
+      "fieldTag": "p",
+      "marcTag": "260",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "London,"
+        },
+        {
+          "tag": "b",
+          "content": "Printed for Robert Scholey,"
+        },
+        {
+          "tag": "c",
+          "content": "1814."
+        }
+      ]
+    },
+    {
+      "fieldTag": "q",
+      "marcTag": "852",
+      "ind1": "8",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "h",
+          "content": "Arents S 0937"
+        }
+      ]
+    },
+    {
+      "fieldTag": "r",
+      "marcTag": "300",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "vii, 191 p."
+        },
+        {
+          "tag": "b",
+          "content": "col. illus."
+        },
+        {
+          "tag": "c",
+          "content": "22 cm."
+        }
+      ]
+    },
+    {
+      "fieldTag": "t",
+      "marcTag": "245",
+      "ind1": "0",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Something concerning Nobody."
+        },
+        {
+          "tag": "c",
+          "content": "Edited by Somebody. Embellished with fourteen characteristic etchings."
+        }
+      ]
+    },
+    {
+      "fieldTag": "u",
+      "marcTag": "740",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Somebody."
+        }
+      ]
+    },
+    {
+      "fieldTag": "v",
+      "marcTag": "959",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": ".b12094201"
+        },
+        {
+          "tag": "b",
+          "content": "08-14-06"
+        },
+        {
+          "tag": "c",
+          "content": "08-01-91"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "856",
+      "ind1": "4",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "u",
+          "content": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Something+concerning+Nobody.&Site=SASAR&CallNumber=Arents+S+0937&ItemPlace=London,&ItemPublisher=Printed+for+Robert+Scholey,&Date=1814.&Site=SASAR"
+        },
+        {
+          "tag": "z",
+          "content": "Request Access to Special Collections Material"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "008",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "741119s1814    enka          00| p|eng|dcam   ",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "005",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "20000629170733.0",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "040",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "NN"
+        },
+        {
+          "tag": "c",
+          "content": "NN"
+        },
+        {
+          "tag": "d",
+          "content": "WaOLN"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "997",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "hsa"
+        },
+        {
+          "tag": "b",
+          "content": "10-05-00"
+        },
+        {
+          "tag": "c",
+          "content": "m"
+        },
+        {
+          "tag": "d",
+          "content": "a"
+        },
+        {
+          "tag": "e",
+          "content": "-"
+        },
+        {
+          "tag": "f",
+          "content": "eng"
+        },
+        {
+          "tag": "g",
+          "content": "enk"
+        },
+        {
+          "tag": "h",
+          "content": "0"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "991",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "y",
+          "content": "62910958"
+        }
+      ]
+    },
+    {
+      "fieldTag": "_",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "00000cam  2200253   4500",
+      "subfields": null
+    }
+  ]
+}


### PR DESCRIPTION
Fixes bug where e-resources whose URL starts with https are skipped
because the check looks for http: (which appears to have matched all
known e-resources at one time. This update handles both http and https
resources. Includes test.