### PR TITLE
Improves handling of missing item type

### DIFF
--- a/lib/items-updater.js
+++ b/lib/items-updater.js
@@ -64,7 +64,7 @@ class ItemsUpdater extends UpdaterBase {
   extractStatements (item) {
     return this.statementsForItem(item)
       .catch((e) => {
-        console.log('error extracting stmts: ', e)
+        console.log(`error extracting stmts from item ${item.nyplSource}/${item.id}: `, e)
         console.trace(e)
         return this.saveToDisc(item).then((r) => {
           console.log('Saved problematic item to disk: ', r.path)

--- a/lib/models/item-sierra-record.js
+++ b/lib/models/item-sierra-record.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const log = require('loglevel')
+
 const sierraLocationMapping = require('@nypl/nypl-core-objects')('by-sierra-location')
 const catalogItemTypeMapping = require('@nypl/nypl-core-objects')('by-catalog-item-type')
 const SierraRecord = require('./sierra-record')
@@ -41,9 +43,13 @@ class ItemSierraRecord extends SierraRecord {
     const itemType = this.getItemType()
     let itemTypeImpliesResearch = false
     if (itemType) {
-      // The item's itype implies 'Research' if the itype collectionType includes 'Research'
-      const collectionTypes = catalogItemTypeMapping[itemType].collectionType
-      itemTypeImpliesResearch = collectionTypes && collectionTypes.indexOf('Research') >= 0
+      if (!catalogItemTypeMapping[itemType]) {
+        log.warn(`Unrecognized itemType: ${itemType}`)
+      } else {
+        // The item's itype implies 'Research' if the itype collectionType includes 'Research'
+        const collectionTypes = catalogItemTypeMapping[itemType].collectionType
+        itemTypeImpliesResearch = collectionTypes && collectionTypes.indexOf('Research') >= 0
+      }
     }
 
     /*

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "deploy-development": "./node_modules/.bin/node-lambda deploy -e development -f ./config/development.env -b subnet-f4fe56af -g sg-1d544067 --role arn:aws:iam::224280085904:role/lambda_basic_execution --profile nypl-sandbox -S config/event-sources-development.json",
     "deploy-qa": "./node_modules/.bin/node-lambda deploy -e qa -f ./config/qa.env -b subnet-21a3b244,subnet-f35de0a9 -g sg-aa74f1db --role arn:aws:iam::946183545209:role/lambda-full-access --profile nypl-digital-dev -S config/event-sources-qa.json",
     "deploy-production": "./node_modules/.bin/node-lambda deploy -e production -f ./config/production.env -b subnet-59bcdd03,subnet-5deecd15 -g sg-116eeb60 --role arn:aws:iam::946183545209:role/lambda-full-access --profile nypl-digital-dev -S config/event-sources-production.json",
-    "run-qa": "AWS_PROFILE=nypl-sandbox ./node_modules/.bin/node-lambda run -f ./config/qa.env"
+    "run-qa": "AWS_PROFILE=nypl-digital-dev ./node_modules/.bin/node-lambda run -f ./config/qa.env"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
Currently, if an item has a Item Type that is not mapped in NYPL Core,
the poster errors hard. This fixes that by skipping the Item Type check
for unmapped Item Types. When determining whether or not an item is
"research", Item Type is one of multiple checks we make. If an item has
an unmapped Item Type, this change will cause its Item Type to *not*
contribute to its designation as a "research" item; It may still be
considered "research" if other checks pass.

This fix will accompany an update to NYPL-Core to add missing Item Types
that are creating trouble in production.

Includes an unrelated update the profile used when running `npm run run-qa`
which was using a largely deprecated profile.