### PR TITLE
Adds support for excluding queried subfields

### DIFF
--- a/lib/models/sierra-record.js
+++ b/lib/models/sierra-record.js
@@ -159,6 +159,7 @@ class SierraRecord {
   //  * tagSubfields: If true, returns a hash of subfield values (rather than joining the values in a single string)
   //  * subfieldJoiner: Character to join subfield values. Default ' '
   //  * preFilter: Optional function to filter out matching marc blocks before extracting value. Useful for checking atypical properties like `ind1`.
+  //  * excludeSubfields: Optional array identifying subfields that should be excluded (e.g. ['0', '6'])
   varField (marc, subfields, opts) {
     var varFields = this._varFieldByMarcTag(marc)
     return this._extractValuesFromVarFields(varFields, subfields, opts)
@@ -182,16 +183,19 @@ class SierraRecord {
     opts = Object.assign({
       tagSubfields: false,
       subfieldJoiner: ' ',
-      preFilter: (block) => true
+      preFilter: (block) => true,
+      excludeSubfields: []
     }, opts)
 
     if (varFields.length) {
       var vals = varFields.filter(opts.preFilter).map((f) => {
         // sometimes there's a case error...
-        var _subFields = f.subFields || f.subfields
+        var recordSubFields = f.subFields || f.subfields
 
         // return subfields based on options
-        var subfieldParse = (subs) => {
+        const subfieldParse = (subs) => {
+          // Remove any sufield we're meant to exclude
+          subs = subs.filter((sub) => !opts.excludeSubfields.includes(sub.tag))
           if (opts.tagSubfields) {
             return subs.reduce((hash, sub) => {
               hash[sub.tag] = sub.content
@@ -204,11 +208,11 @@ class SierraRecord {
 
         // If asked to match certain subfields, return only those:
         if (subfields) {
-          var subs = (_subFields || []).filter((sub) => subfields.indexOf(sub.tag) >= 0)
+          var subs = (recordSubFields || []).filter((sub) => subfields.indexOf(sub.tag) >= 0)
           return subfieldParse(subs)
         // Otherwise, attempt to return 'content', falling back on subfields' content:
         } else {
-          return f.content || (_subFields ? subfieldParse(_subFields) : null)
+          return f.content || (recordSubFields ? subfieldParse(recordSubFields) : null)
         }
       })
       return [].concat.apply([], vals).filter((v) => v)

--- a/test/sierra-record-test.js
+++ b/test/sierra-record-test.js
@@ -27,4 +27,53 @@ describe('SierraRecord', function () {
       expect(title[0]).to.eq('ʻOrekh ha-din be-Yiśraʾel : maʻamado, zekhuyotaṿ ṿe-ḥovotaṿ : leḳeṭ dinim ṿe-halakhot / ba-ʻarikhat S. Ginosar.')
     })
   })
+
+  describe('varField', function () {
+    it('able to return tagged subfields', function () {
+      const record = new SierraRecord(require('./data/bib-10001936.json'))
+      // Get title using all subfields
+      const title = record.varField('245', null, { tagSubfields: true })
+      expect(title).to.be.a('array')
+      expect(title[0]).to.deep.include({
+        a: 'Niwtʻer azgayin patmutʻian hamar',
+        b: 'Ereveli hay kazunkʻ ; Parskastan /',
+        c: 'Ashkhatasirutʻiamb Galust Shermazaniani.'
+      })
+    })
+
+    it('able to return tagged subfields with certain subfields excluded', function () {
+      const record = new SierraRecord(require('./data/bib-10001936.json'))
+      // Get title using all subfields
+      const title = record.varField('245', null, { tagSubfields: true, excludeSubfields: ['b'] })
+      expect(title).to.be.a('array')
+      expect(title[0]).to.deep.include({
+        a: 'Niwtʻer azgayin patmutʻian hamar',
+        c: 'Ashkhatasirutʻiamb Galust Shermazaniani.'
+      })
+    })
+
+    it('able to return single string from all subfields', function () {
+      const record = new SierraRecord(require('./data/bib-10001936.json'))
+      // Get title using all subfields
+      const title = record.varField('245')
+      expect(title).to.be.a('array')
+      expect(title[0]).to.eq('Niwtʻer azgayin patmutʻian hamar Ereveli hay kazunkʻ ; Parskastan / Ashkhatasirutʻiamb Galust Shermazaniani.')
+    })
+
+    it('able to return single string from all subfields, excluding some subfields', function () {
+      const record = new SierraRecord(require('./data/bib-10001936.json'))
+      // Get title using all subfields
+      const title = record.varField('245', null, { excludeSubfields: ['b'] })
+      expect(title).to.be.a('array')
+      expect(title[0]).to.eq('Niwtʻer azgayin patmutʻian hamar Ashkhatasirutʻiamb Galust Shermazaniani.')
+    })
+
+    it('able to return single string from certain subfields', function () {
+      const record = new SierraRecord(require('./data/bib-10001936.json'))
+      // Get title using all subfields
+      const title = record.varField('245', ['a', 'c'], { excludeSubfields: ['b'] })
+      expect(title).to.be.a('array')
+      expect(title[0]).to.eq('Niwtʻer azgayin patmutʻian hamar Ashkhatasirutʻiamb Galust Shermazaniani.')
+    })
+  })
 })


### PR DESCRIPTION
Updates SierraRecord#varField to add support for excluding specific
subfields.

For example, the following retrieves a single string composed of all
subfields in marc 791 without subfields $0 and $6:

`bib.varField('791', null, { excludeSubfields: [ '0', '6'])`