### PR TITLE
Identify OTF bibs by 910

### DIFF
--- a/lib/models/bib-sierra-record.js
+++ b/lib/models/bib-sierra-record.js
@@ -242,7 +242,14 @@ class BibSierraRecord extends SierraRecord {
   isOtfRecord () {
     // Location code 'os' is a special location for temporary items
     // https://github.com/NYPL/nypl-core/blob/master/vocabularies/csv/locations.csv#L2265
-    return this.locations && this.locations[0] && this.locations[0].code === 'os'
+    const hasOtfLocation = this.locations && this.locations[0] && this.locations[0].code === 'os'
+
+    // Having 910 $a === 'RLOTF' is also a solid indicator introduced in OTF
+    // record creation Oct 2021 https://github.com/NYPL/recap-hold-request-consumer/pull/33
+    const varfield910 = this.varField('910', 'a')
+    const hasOtf910 = Array.isArray(varfield910) && varfield910[0] === 'RLOTF'
+
+    return hasOtfLocation || hasOtf910
   }
 }
 

--- a/test/bib-sierra-record-test.js
+++ b/test/bib-sierra-record-test.js
@@ -11,8 +11,17 @@ describe('BibSierraRecord', function () {
       expect(record.isOtfRecord()).to.eq(false)
     })
 
-    it('flags OTF Bib', function () {
+    it('flags OTF Bib based on location', function () {
       const record = new BibSierraRecord(require('./data/bib-22180568-otf.json'))
+      expect(record.isNyplRecord()).to.eq(true)
+      expect(record.isPartnerRecord()).to.eq(false)
+
+      // Check is-otf:
+      expect(record.isOtfRecord()).to.eq(true)
+    })
+
+    it('flags OTF Bib based on 910', function () {
+      const record = new BibSierraRecord(require('./data/bib-22180848-otf.json'))
       expect(record.isNyplRecord()).to.eq(true)
       expect(record.isPartnerRecord()).to.eq(false)
 

--- a/test/data/bib-22180848-otf.json
+++ b/test/data/bib-22180848-otf.json
@@ -1,0 +1,123 @@
+{
+  "id": "22180848",
+  "updatedDate": "2021-10-29T01:00:01Z",
+  "createdDate": "2021-10-28T16:21:43Z",
+  "deleted": false,
+  "suppressed": false,
+  "lang": {
+      "code": "   ",
+      "name": "---"
+  },
+  "title": "[Standard NYPL restrictions apply] TOAST / BY RICHARD BEAN. [RECAP]",
+  "author": "Bean, Richard, 1956-",
+  "materialType": {
+      "code": "-  ",
+      "value": "MISC"
+  },
+  "bibLevel": {
+      "code": "-",
+      "value": "---"
+  },
+  "country": {
+      "code": "   ",
+      "name": "No country"
+  },
+  "fixedFields": {
+      "24": {
+          "label": "Language",
+          "value": "   ",
+          "display": "---"
+      },
+      "25": {
+          "label": "Skip",
+          "value": "0"
+      },
+      "26": {
+          "label": "Location",
+          "value": "os   ",
+          "display": "OFFSITE - ReCAP Partner"
+      },
+      "27": {
+          "label": "COPIES",
+          "value": "0"
+      },
+      "29": {
+          "label": "Bib Level",
+          "value": "-",
+          "display": "---"
+      },
+      "30": {
+          "label": "Material Type",
+          "value": "-  ",
+          "display": "MISC"
+      },
+      "31": {
+          "label": "Bib Code 3",
+          "value": "-"
+      },
+      "80": {
+          "label": "Record Type",
+          "value": "b"
+      },
+      "81": {
+          "label": "Record Number",
+          "value": "22180848"
+      },
+      "83": {
+          "label": "Created Date",
+          "value": "2021-10-28T16:21:43Z"
+      },
+      "84": {
+          "label": "Updated Date",
+          "value": "2021-10-29T01:00:01Z"
+      },
+      "85": {
+          "label": "No. of Revisions",
+          "value": "2"
+      },
+      "86": {
+          "label": "Agency",
+          "value": "1"
+      },
+      "89": {
+          "label": "Country",
+          "value": "   ",
+          "display": "No country"
+      },
+      "98": {
+          "label": "PDATE",
+          "value": "2021-10-28T16:21:46Z"
+      },
+      "107": {
+          "label": "MARC Type",
+          "value": " "
+      }
+  },
+  "varFields": [
+      {
+          "fieldTag": "a",
+          "content": "Bean, Richard, 1956-   "
+      },
+      {
+          "fieldTag": "t",
+          "content": "[Standard NYPL restrictions apply] TOAST / BY RICHARD BEAN. [RECAP]"
+      },
+      {
+          "fieldTag": "y",
+          "marcTag": "910",
+          "ind1": " ",
+          "ind2": " ",
+          "subfields": [
+              {
+                  "tag": "a",
+                  "content": "RLOTF"
+              }
+          ]
+      },
+      {
+          "fieldTag": "_",
+          "content": "00000nam  2200000 a 4500"
+      }
+  ],
+  "nyplSource": "sierra-nypl"
+}


### PR DESCRIPTION
Changes OTF check to identify OTF bibs by presense of 910 $a ===
'RLOTF', which is being dropped by RecapHoldRequestConsumer
https://github.com/NYPL/recap-hold-request-consumer/pull/33

https://jira.nypl.org/browse/SCC-2888