### PR TITLE
Add better oclc number extraction

### DIFF
--- a/lib/serializers/bib.js
+++ b/lib/serializers/bib.js
@@ -267,6 +267,27 @@ var fromMarcJson = (object, datasource) => {
       })
     })
 
+    // Extract OCLC numbers:
+    const oclcFieldMapping = fieldMapper.getMapping('OCLC number')
+    oclcFieldMapping.paths.forEach((path) => {
+      // Extract value by marc & subfields
+      let vals = object.varField(path.marc, path.subfields)
+      // Reject identifiers in 035 $a that aren't prefixed "(OCoLC)"
+      if (path.marc === '035') {
+        vals = vals.filter((id) => id.includes('(OCoLC)'))
+          .map((id) => id.replace(/^\(OCoLC\)/, ''))
+      }
+
+      // Build provo path
+      var recordPath = path.marc
+      if (path.subfields) recordPath += ' ' + path.subfields.map((s) => `$${s}`).join(' ')
+
+      vals.forEach((id) => {
+        const type = 'nypl:Oclc'
+        builder.add(oclcFieldMapping.pred, { id, type }, null, { path: recordPath })
+      })
+    })
+
     // Parse a bunch of generic bf:Identifier typed identifiers.
     // These are "Standard numbers" in Sierra parlance, which include
     // identifiers for different domains and classifications, which

--- a/test/bib-marc-test.js
+++ b/test/bib-marc-test.js
@@ -1147,8 +1147,8 @@ describe('Bib Marc Mapping', function () {
           expect(bib.statements('dcterms:identifier')[1].object_id).to.be.eq('he^76953970^')
           expect(bib.statements('dcterms:identifier')[1].object_type).to.be.eq('bf:Lccn')
           expect(bib.statements('dcterms:identifier')[2]).to.be.a('object')
-          expect(bib.statements('dcterms:identifier')[2].object_id).to.be.eq('(OCoLC)19176985')
-          expect(bib.statements('dcterms:identifier')[2].object_type).to.be.eq('bf:Identifier')
+          expect(bib.statements('dcterms:identifier')[2].object_id).to.be.eq('19176985')
+          expect(bib.statements('dcterms:identifier')[2].object_type).to.be.eq('nypl:Oclc')
         })
     })
 
@@ -1175,8 +1175,8 @@ describe('Bib Marc Mapping', function () {
           expect(bib.statements('dcterms:identifier')[0].object_id).to.be.eq('990137923810203941')
           expect(bib.statements('dcterms:identifier')[0].object_type).to.be.eq('nypl:Bnumber')
           expect(bib.statements('dcterms:identifier')[1]).to.be.a('object')
-          expect(bib.statements('dcterms:identifier')[1].object_id).to.be.eq('(OCoLC)860431222')
-          expect(bib.statements('dcterms:identifier')[1].object_type).to.be.eq('bf:Identifier')
+          expect(bib.statements('dcterms:identifier')[1].object_id).to.be.eq('860431222')
+          expect(bib.statements('dcterms:identifier')[1].object_type).to.be.eq('nypl:Oclc')
         })
     })
   })
@@ -1224,6 +1224,41 @@ describe('Bib Marc Mapping', function () {
         .then((statements) => new Bib(statements))
         .then((bib) => {
           expect(bib.literal('dcterms:alternative')).to.not.include('Excluded alternative title')
+        })
+    })
+  })
+
+  describe('OCLC', function () {
+    it('should extract OCLC from 991 $a', function () {
+      const bib = BibSierraRecord.from(require('./data/bib-11074570.json'))
+      return bibSerializer.fromMarcJson(bib)
+        .then((statements) => new Bib(statements))
+        .then((bib) => {
+          const oclcStatements = bib.statements('dcterms:identifier')
+            .filter((statement) => statement.object_type === 'nypl:Oclc')
+
+          expect(oclcStatements[0]).to.be.a('object')
+          expect(oclcStatements[0].object_id).to.eq('14083629')
+          expect(oclcStatements[0].source_record_path).to.eq('991 $y')
+
+          // There also a 035 $a in this record with (WaOLN)nyp031187
+          // Make sure above is the only identified OCLC number
+          expect(oclcStatements).to.have.lengthOf(1)
+        })
+    })
+
+    it('should extract OCLC from 035 $a', function () {
+      const bib = BibSierraRecord.from(require('./data/bib-20522059.json'))
+      return bibSerializer.fromMarcJson(bib)
+        .then((statements) => new Bib(statements))
+        .then((bib) => {
+          const oclcStatements = bib.statements('dcterms:identifier')
+            .filter((statement) => statement.object_type === 'nypl:Oclc')
+
+          expect(oclcStatements).to.have.lengthOf(1)
+          expect(oclcStatements[0]).to.be.a('object')
+          expect(oclcStatements[0].object_id).to.eq('901573922')
+          expect(oclcStatements[0].source_record_path).to.eq('035 $a')
         })
     })
   })

--- a/test/data/bib-11074570.json
+++ b/test/data/bib-11074570.json
@@ -1,0 +1,424 @@
+{
+  "id": "11074570",
+  "nyplSource": "sierra-nypl",
+  "nyplType": "bib",
+  "updatedDate": "2021-10-18T00:20:00-04:00",
+  "createdDate": "2008-12-14T17:02:00-05:00",
+  "deletedDate": null,
+  "deleted": false,
+  "locations": [
+    {
+      "code": "mak",
+      "name": "SASB - Dewitt Wallace Room 108"
+    },
+    {
+      "code": "mal",
+      "name": "SASB - Service Desk Rm 315"
+    }
+  ],
+  "suppressed": false,
+  "lang": {
+    "code": "spa",
+    "name": "Spanish"
+  },
+  "title": "Brecha.",
+  "author": "",
+  "materialType": {
+    "code": "a  ",
+    "value": "BOOK/TEXT"
+  },
+  "bibLevel": {
+    "code": "s",
+    "value": "SERIAL"
+  },
+  "publishYear": 1985,
+  "catalogDate": "2001-01-03",
+  "country": {
+    "code": "uy ",
+    "name": "Uruguay"
+  },
+  "normTitle": "brecha",
+  "normAuthor": "",
+  "standardNumbers": [],
+  "controlNumber": "NYPG86-S4673",
+  "fixedFields": {
+    "24": {
+      "label": "Language",
+      "value": "spa",
+      "display": "Spanish"
+    },
+    "25": {
+      "label": "Skip",
+      "value": "0",
+      "display": null
+    },
+    "26": {
+      "label": "Location",
+      "value": "multi",
+      "display": null
+    },
+    "27": {
+      "label": "COPIES",
+      "value": "0",
+      "display": null
+    },
+    "28": {
+      "label": "Cat. Date",
+      "value": "2001-01-03",
+      "display": null
+    },
+    "29": {
+      "label": "Bib Level",
+      "value": "s",
+      "display": "SERIAL"
+    },
+    "30": {
+      "label": "Material Type",
+      "value": "a  ",
+      "display": "BOOK/TEXT"
+    },
+    "31": {
+      "label": "Bib Code 3",
+      "value": "-",
+      "display": null
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "b",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "11074570",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": "2008-12-14T17:02:00Z",
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2021-10-18T00:20:00Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": "95",
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "1",
+      "display": null
+    },
+    "89": {
+      "label": "Country",
+      "value": "uy ",
+      "display": "Uruguay"
+    },
+    "98": {
+      "label": "PDATE",
+      "value": "2021-04-20T20:12:32Z",
+      "display": null
+    },
+    "107": {
+      "label": "MARC Type",
+      "value": " ",
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "fieldTag": "c",
+      "marcTag": "852",
+      "ind1": "8",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "h",
+          "content": "JFP 05-15"
+        }
+      ]
+    },
+    {
+      "fieldTag": "l",
+      "marcTag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "(WaOLN)nyp0311870"
+        }
+      ]
+    },
+    {
+      "fieldTag": "o",
+      "marcTag": "001",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "NYPG86-S4673",
+      "subfields": null
+    },
+    {
+      "fieldTag": "p",
+      "marcTag": "260",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Montevideo :"
+        },
+        {
+          "tag": "b",
+          "content": "Brecha,"
+        },
+        {
+          "tag": "c",
+          "content": "[1985]-"
+        }
+      ]
+    },
+    {
+      "fieldTag": "q",
+      "marcTag": "852",
+      "ind1": "8",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "h",
+          "content": "JFP 05-15"
+        }
+      ]
+    },
+    {
+      "fieldTag": "r",
+      "marcTag": "300",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "v. ;"
+        },
+        {
+          "tag": "c",
+          "content": "41 cm."
+        }
+      ]
+    },
+    {
+      "fieldTag": "r",
+      "marcTag": "362",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Año 1, no. 1 (11 de oct. de 1985)-"
+        }
+      ]
+    },
+    {
+      "fieldTag": "t",
+      "marcTag": "245",
+      "ind1": "0",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Brecha."
+        }
+      ]
+    },
+    {
+      "fieldTag": "t",
+      "marcTag": "130",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Brecha (Montevideo, Uruguay)"
+        }
+      ]
+    },
+    {
+      "fieldTag": "u",
+      "marcTag": "299",
+      "ind1": "0",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Brecha."
+        }
+      ]
+    },
+    {
+      "fieldTag": "u",
+      "marcTag": "799",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Gift of the DeWitt Wallace Endowment Fund, named in honor of the founder of Reader's Digest"
+        }
+      ]
+    },
+    {
+      "fieldTag": "v",
+      "marcTag": "959",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": ".b2095119x"
+        },
+        {
+          "tag": "b",
+          "content": "04-08-08"
+        },
+        {
+          "tag": "c",
+          "content": "08-26-91"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "003",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "CStRLIN",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "005",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "20000925124725.0",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "008",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "860624c19859999uy uu ne      0   a0spa dcas a ",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "040",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "NN"
+        },
+        {
+          "tag": "c",
+          "content": "NN"
+        },
+        {
+          "tag": "d",
+          "content": "WaOLN"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "997",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "hp"
+        },
+        {
+          "tag": "b",
+          "content": "01-03-01"
+        },
+        {
+          "tag": "c",
+          "content": "s"
+        },
+        {
+          "tag": "d",
+          "content": "a"
+        },
+        {
+          "tag": "e",
+          "content": "-"
+        },
+        {
+          "tag": "f",
+          "content": "spa"
+        },
+        {
+          "tag": "g",
+          "content": "uy "
+        },
+        {
+          "tag": "h",
+          "content": "0"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "991",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "y",
+          "content": "14083629"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "911",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "RL"
+        }
+      ]
+    },
+    {
+      "fieldTag": "_",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "00000cas  2200217 a 4500",
+      "subfields": null
+    }
+  ]
+}

--- a/test/data/bib-20522059.json
+++ b/test/data/bib-20522059.json
@@ -1,0 +1,12040 @@
+{
+  "id": "20522059",
+  "nyplSource": "sierra-nypl",
+  "nyplType": "bib",
+  "updatedDate": "2021-10-25T09:14:20-04:00",
+  "createdDate": "2015-02-02T14:38:14-05:00",
+  "deletedDate": null,
+  "deleted": false,
+  "locations": [
+    {
+      "code": "mao",
+      "name": "SASB - Manuscripts & Archives Rm 328"
+    }
+  ],
+  "suppressed": false,
+  "lang": {
+    "code": "eng",
+    "name": "English"
+  },
+  "title": "Tom Wolfe papers, (bulk 1960-1998).",
+  "author": "Wolfe, Tom.",
+  "materialType": {
+    "code": "p  ",
+    "value": "ARCHIVAL MIX"
+  },
+  "bibLevel": {
+    "code": "7",
+    "value": "ARCHIVES & MSS"
+  },
+  "publishYear": 1930,
+  "catalogDate": "2015-02-02",
+  "country": {
+    "code": "nyu",
+    "name": "New York (State)"
+  },
+  "normTitle": "tom wolfe papers bulk 1960 1998",
+  "normAuthor": "wolfe tom",
+  "standardNumbers": [],
+  "controlNumber": "901573922",
+  "fixedFields": {
+    "24": {
+      "label": "Language",
+      "value": "eng",
+      "display": "English"
+    },
+    "25": {
+      "label": "Skip",
+      "value": "0",
+      "display": null
+    },
+    "26": {
+      "label": "Location",
+      "value": "mao  ",
+      "display": "SASB - Manuscripts & Archives Rm 328"
+    },
+    "27": {
+      "label": "COPIES",
+      "value": "228",
+      "display": null
+    },
+    "28": {
+      "label": "Cat. Date",
+      "value": "2015-02-02",
+      "display": null
+    },
+    "29": {
+      "label": "Bib Level",
+      "value": "7",
+      "display": "ARCHIVES & MSS"
+    },
+    "30": {
+      "label": "Material Type",
+      "value": "p  ",
+      "display": "ARCHIVAL MIX"
+    },
+    "31": {
+      "label": "Bib Code 3",
+      "value": "-",
+      "display": null
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "b",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "20522059",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": "2015-02-02T14:38:14Z",
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2021-10-25T09:14:20Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": "6",
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "1",
+      "display": null
+    },
+    "89": {
+      "label": "Country",
+      "value": "nyu",
+      "display": "New York (State)"
+    },
+    "98": {
+      "label": "PDATE",
+      "value": "2021-01-25T22:26:44Z",
+      "display": null
+    },
+    "107": {
+      "label": "MARC Type",
+      "value": " ",
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "fieldTag": "a",
+      "marcTag": "100",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Wolfe, Tom."
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Buckley, William F.,"
+        },
+        {
+          "tag": "c",
+          "content": "Jr.,"
+        },
+        {
+          "tag": "d",
+          "content": "1925-2008."
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Dietz, Lawrence."
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Lish, Gordon."
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Strachan, Patricia."
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Straus, Roger W."
+        },
+        {
+          "tag": "q",
+          "content": "(Roger Williams),"
+        },
+        {
+          "tag": "d",
+          "content": "1917-2004."
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Thompson, Hunter S."
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Tyrrell, R. Emmett."
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Van Petten, O. W."
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Wenner, Jann."
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Wong, Kailey."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "610",
+      "ind1": "2",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Farrar, Straus, and Giroux."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "American literature"
+        },
+        {
+          "tag": "y",
+          "content": "20th century."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Authors and publishers."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Authors and readers."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Authors, American"
+        },
+        {
+          "tag": "y",
+          "content": "20th century."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Journalism"
+        },
+        {
+          "tag": "z",
+          "content": "United States."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Nonfiction novel."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Social realism in literature."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "651",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "United States"
+        },
+        {
+          "tag": "x",
+          "content": "Social life and customs"
+        },
+        {
+          "tag": "y",
+          "content": "20th century."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "655",
+      "ind1": " ",
+      "ind2": "7",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Drawings (visual works)"
+        },
+        {
+          "tag": "2",
+          "content": "aat"
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "655",
+      "ind1": " ",
+      "ind2": "7",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Galley proofs."
+        },
+        {
+          "tag": "2",
+          "content": "aat"
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "655",
+      "ind1": " ",
+      "ind2": "7",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Lectures."
+        },
+        {
+          "tag": "2",
+          "content": "aat"
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "655",
+      "ind1": " ",
+      "ind2": "7",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Manuscripts (document genre)"
+        },
+        {
+          "tag": "2",
+          "content": "aat"
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "655",
+      "ind1": " ",
+      "ind2": "7",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Manuscripts for publication."
+        },
+        {
+          "tag": "2",
+          "content": "aat"
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "655",
+      "ind1": " ",
+      "ind2": "7",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Photographs."
+        },
+        {
+          "tag": "2",
+          "content": "aat"
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "655",
+      "ind1": " ",
+      "ind2": "7",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Research notes."
+        },
+        {
+          "tag": "2",
+          "content": "aat"
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "655",
+      "ind1": " ",
+      "ind2": "7",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Screenplays."
+        },
+        {
+          "tag": "2",
+          "content": "aat"
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "655",
+      "ind1": " ",
+      "ind2": "7",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Scripts (documents)"
+        },
+        {
+          "tag": "2",
+          "content": "aat"
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "655",
+      "ind1": " ",
+      "ind2": "7",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Shorthand."
+        },
+        {
+          "tag": "2",
+          "content": "aat"
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "655",
+      "ind1": " ",
+      "ind2": "7",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Sketches."
+        },
+        {
+          "tag": "2",
+          "content": "aat"
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "655",
+      "ind1": " ",
+      "ind2": "7",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Sound recordings."
+        },
+        {
+          "tag": "2",
+          "content": "aat"
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "656",
+      "ind1": " ",
+      "ind2": "7",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Authors"
+        },
+        {
+          "tag": "z",
+          "content": "United States."
+        },
+        {
+          "tag": "2",
+          "content": "lcsh"
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "656",
+      "ind1": " ",
+      "ind2": "7",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Journalists"
+        },
+        {
+          "tag": "z",
+          "content": "United States."
+        },
+        {
+          "tag": "2",
+          "content": "lcsh"
+        }
+      ]
+    },
+    {
+      "fieldTag": "l",
+      "marcTag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "(OCoLC)901573922"
+        }
+      ]
+    },
+    {
+      "fieldTag": "m",
+      "marcTag": "541",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Purchased from Tom Wolfe, 2014. Additions donated by Sheila Wolfe, 2019"
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "506",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Advance notice required. Apply at http://www.nypl.org/mssref. Some files from Series I and Series V are closed until 2034 and 2039 per seller agreement."
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "520",
+      "ind1": "3",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Tom Wolfe is an American author and journalist known for such works as The Electric Kool-Aid Acid Test, The Right Stuff, and The Bonfire of the Vanities. He is credited with reviving the social realism genre in fiction and is a pioneer of the New Journalism. The Tom Wolfe papers, dated 1930 to 2016, comprehensively document Wolfe's career, providing insight into his writing process and the development of his signature style; the professional relationships he maintained with editors, writers, and cultural critics; his social life in New York City; and readers' responses to his published work. The collection includes draft manuscripts, outlines, research files, correspondence, lectures, photographs, and drawings."
+        }
+      ]
+    },
+    {
+      "fieldTag": "o",
+      "marcTag": "001",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "901573922",
+      "subfields": null
+    },
+    {
+      "fieldTag": "q",
+      "marcTag": "852",
+      "ind1": "8",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "h",
+          "content": "MssCol 22833"
+        }
+      ]
+    },
+    {
+      "fieldTag": "r",
+      "marcTag": "300",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "98.03 linear feet (236 boxes, 1 volume, 4 oversize folders, 8 audio files)"
+        }
+      ]
+    },
+    {
+      "fieldTag": "t",
+      "marcTag": "245",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Tom Wolfe papers,"
+        },
+        {
+          "tag": "f",
+          "content": "1930-2016"
+        },
+        {
+          "tag": "g",
+          "content": "(bulk 1960-1998)."
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "003",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "OCoLC",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "005",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "20150130154934.0",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "008",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "150130i19302013nyu                 eng dnpcIaa",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "040",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "NYP"
+        },
+        {
+          "tag": "c",
+          "content": "NYP"
+        },
+        {
+          "tag": "e",
+          "content": "dacs"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "049",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "NYPP"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "901",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "was"
+        },
+        {
+          "tag": "b",
+          "content": "ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "901",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "MARS"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "946",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "m"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423235"
+        },
+        {
+          "tag": "c",
+          "content": "box 1"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423243"
+        },
+        {
+          "tag": "c",
+          "content": "box 2"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423250"
+        },
+        {
+          "tag": "c",
+          "content": "box 3"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423268"
+        },
+        {
+          "tag": "c",
+          "content": "box 4"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423276"
+        },
+        {
+          "tag": "c",
+          "content": "box 5"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423284"
+        },
+        {
+          "tag": "c",
+          "content": "box 6"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423292"
+        },
+        {
+          "tag": "c",
+          "content": "box 7"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423300"
+        },
+        {
+          "tag": "c",
+          "content": "box 8"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423318"
+        },
+        {
+          "tag": "c",
+          "content": "box 9"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423326"
+        },
+        {
+          "tag": "c",
+          "content": "box 10"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423334"
+        },
+        {
+          "tag": "c",
+          "content": "box 11"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423342"
+        },
+        {
+          "tag": "c",
+          "content": "box 12"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423359"
+        },
+        {
+          "tag": "c",
+          "content": "box 13"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423367"
+        },
+        {
+          "tag": "c",
+          "content": "box 14"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423375"
+        },
+        {
+          "tag": "c",
+          "content": "box 15"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423383"
+        },
+        {
+          "tag": "c",
+          "content": "box 16"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423391"
+        },
+        {
+          "tag": "c",
+          "content": "box 17"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423409"
+        },
+        {
+          "tag": "c",
+          "content": "box 18"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423417"
+        },
+        {
+          "tag": "c",
+          "content": "box 19"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423425"
+        },
+        {
+          "tag": "c",
+          "content": "box 20"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423433"
+        },
+        {
+          "tag": "c",
+          "content": "box 21"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423441"
+        },
+        {
+          "tag": "c",
+          "content": "box 22"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423458"
+        },
+        {
+          "tag": "c",
+          "content": "box 23"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423466"
+        },
+        {
+          "tag": "c",
+          "content": "box 24"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423474"
+        },
+        {
+          "tag": "c",
+          "content": "box 25"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423482"
+        },
+        {
+          "tag": "c",
+          "content": "box 26"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423490"
+        },
+        {
+          "tag": "c",
+          "content": "box 27"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423508"
+        },
+        {
+          "tag": "c",
+          "content": "box 28"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423516"
+        },
+        {
+          "tag": "c",
+          "content": "box 29"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423524"
+        },
+        {
+          "tag": "c",
+          "content": "box 30"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423532"
+        },
+        {
+          "tag": "c",
+          "content": "box 31"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423540"
+        },
+        {
+          "tag": "c",
+          "content": "box 32"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423557"
+        },
+        {
+          "tag": "c",
+          "content": "box 33"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423565"
+        },
+        {
+          "tag": "c",
+          "content": "box 34"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423573"
+        },
+        {
+          "tag": "c",
+          "content": "box 35"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423581"
+        },
+        {
+          "tag": "c",
+          "content": "box 36"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423599"
+        },
+        {
+          "tag": "c",
+          "content": "box 37"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423607"
+        },
+        {
+          "tag": "c",
+          "content": "box 38"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423615"
+        },
+        {
+          "tag": "c",
+          "content": "box 39"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423623"
+        },
+        {
+          "tag": "c",
+          "content": "box 40"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423631"
+        },
+        {
+          "tag": "c",
+          "content": "box 41"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423649"
+        },
+        {
+          "tag": "c",
+          "content": "box 42"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423656"
+        },
+        {
+          "tag": "c",
+          "content": "box 43"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423664"
+        },
+        {
+          "tag": "c",
+          "content": "box 44"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423672"
+        },
+        {
+          "tag": "c",
+          "content": "box 45"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423680"
+        },
+        {
+          "tag": "c",
+          "content": "box 46"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423698"
+        },
+        {
+          "tag": "c",
+          "content": "box 47"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423706"
+        },
+        {
+          "tag": "c",
+          "content": "box 48"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423714"
+        },
+        {
+          "tag": "c",
+          "content": "box 49"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423722"
+        },
+        {
+          "tag": "c",
+          "content": "box 50"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423730"
+        },
+        {
+          "tag": "c",
+          "content": "box 51"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423748"
+        },
+        {
+          "tag": "c",
+          "content": "box 52"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423755"
+        },
+        {
+          "tag": "c",
+          "content": "box 53"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423763"
+        },
+        {
+          "tag": "c",
+          "content": "box 54"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423771"
+        },
+        {
+          "tag": "c",
+          "content": "box 55"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423789"
+        },
+        {
+          "tag": "c",
+          "content": "box 56"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423797"
+        },
+        {
+          "tag": "c",
+          "content": "box 57"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423805"
+        },
+        {
+          "tag": "c",
+          "content": "box 58"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423813"
+        },
+        {
+          "tag": "c",
+          "content": "box 59"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423821"
+        },
+        {
+          "tag": "c",
+          "content": "box 60"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423839"
+        },
+        {
+          "tag": "c",
+          "content": "box 61"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423847"
+        },
+        {
+          "tag": "c",
+          "content": "box 62"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423854"
+        },
+        {
+          "tag": "c",
+          "content": "box 63"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423862"
+        },
+        {
+          "tag": "c",
+          "content": "box 64"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423870"
+        },
+        {
+          "tag": "c",
+          "content": "box 65"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423029"
+        },
+        {
+          "tag": "c",
+          "content": "box 67"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423037"
+        },
+        {
+          "tag": "c",
+          "content": "box 68"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423045"
+        },
+        {
+          "tag": "c",
+          "content": "box 69"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423052"
+        },
+        {
+          "tag": "c",
+          "content": "box 70"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423060"
+        },
+        {
+          "tag": "c",
+          "content": "box 71"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423078"
+        },
+        {
+          "tag": "c",
+          "content": "box 72"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423086"
+        },
+        {
+          "tag": "c",
+          "content": "box 73"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423094"
+        },
+        {
+          "tag": "c",
+          "content": "box 74"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423102"
+        },
+        {
+          "tag": "c",
+          "content": "box 75"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423110"
+        },
+        {
+          "tag": "c",
+          "content": "box 76"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423128"
+        },
+        {
+          "tag": "c",
+          "content": "box 77"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423136"
+        },
+        {
+          "tag": "c",
+          "content": "box 78"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423144"
+        },
+        {
+          "tag": "c",
+          "content": "box 79"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423151"
+        },
+        {
+          "tag": "c",
+          "content": "box 80"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423169"
+        },
+        {
+          "tag": "c",
+          "content": "box 81"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423177"
+        },
+        {
+          "tag": "c",
+          "content": "box 82"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423185"
+        },
+        {
+          "tag": "c",
+          "content": "box 83"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423193"
+        },
+        {
+          "tag": "c",
+          "content": "box 84"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423201"
+        },
+        {
+          "tag": "c",
+          "content": "box 85"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423219"
+        },
+        {
+          "tag": "c",
+          "content": "box 86"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423227"
+        },
+        {
+          "tag": "c",
+          "content": "box 87"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423888"
+        },
+        {
+          "tag": "c",
+          "content": "box 88"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423896"
+        },
+        {
+          "tag": "c",
+          "content": "box 89"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423904"
+        },
+        {
+          "tag": "c",
+          "content": "box 90"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423912"
+        },
+        {
+          "tag": "c",
+          "content": "box 91"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423920"
+        },
+        {
+          "tag": "c",
+          "content": "box 92"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423938"
+        },
+        {
+          "tag": "c",
+          "content": "box 93"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423946"
+        },
+        {
+          "tag": "c",
+          "content": "box 94"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423953"
+        },
+        {
+          "tag": "c",
+          "content": "box 95"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423961"
+        },
+        {
+          "tag": "c",
+          "content": "box 96"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423979"
+        },
+        {
+          "tag": "c",
+          "content": "box 97"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423987"
+        },
+        {
+          "tag": "c",
+          "content": "box 98"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112423995"
+        },
+        {
+          "tag": "c",
+          "content": "box 99"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424001"
+        },
+        {
+          "tag": "c",
+          "content": "box 100"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424019"
+        },
+        {
+          "tag": "c",
+          "content": "box 101"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424027"
+        },
+        {
+          "tag": "c",
+          "content": "box 102"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424035"
+        },
+        {
+          "tag": "c",
+          "content": "box 103"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424043"
+        },
+        {
+          "tag": "c",
+          "content": "box 104"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424050"
+        },
+        {
+          "tag": "c",
+          "content": "box 105"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424068"
+        },
+        {
+          "tag": "c",
+          "content": "box 106"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424076"
+        },
+        {
+          "tag": "c",
+          "content": "box 107"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424092"
+        },
+        {
+          "tag": "c",
+          "content": "box 108"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424084"
+        },
+        {
+          "tag": "c",
+          "content": "box 109"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424100"
+        },
+        {
+          "tag": "c",
+          "content": "box 110"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424118"
+        },
+        {
+          "tag": "c",
+          "content": "box 111"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424126"
+        },
+        {
+          "tag": "c",
+          "content": "box 112"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424134"
+        },
+        {
+          "tag": "c",
+          "content": "box 113"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424142"
+        },
+        {
+          "tag": "c",
+          "content": "box 114"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424159"
+        },
+        {
+          "tag": "c",
+          "content": "box 115"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424167"
+        },
+        {
+          "tag": "c",
+          "content": "box 116"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424175"
+        },
+        {
+          "tag": "c",
+          "content": "box 117"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424183"
+        },
+        {
+          "tag": "c",
+          "content": "box 118"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424191"
+        },
+        {
+          "tag": "c",
+          "content": "box 119"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424209"
+        },
+        {
+          "tag": "c",
+          "content": "box 120"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424217"
+        },
+        {
+          "tag": "c",
+          "content": "box 121"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424225"
+        },
+        {
+          "tag": "c",
+          "content": "box 122"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424233"
+        },
+        {
+          "tag": "c",
+          "content": "box 123"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424241"
+        },
+        {
+          "tag": "c",
+          "content": "box 124"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424258"
+        },
+        {
+          "tag": "c",
+          "content": "box 125"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424266"
+        },
+        {
+          "tag": "c",
+          "content": "box 126"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424274"
+        },
+        {
+          "tag": "c",
+          "content": "box 127"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424282"
+        },
+        {
+          "tag": "c",
+          "content": "box 128"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424308"
+        },
+        {
+          "tag": "c",
+          "content": "box 129"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424290"
+        },
+        {
+          "tag": "c",
+          "content": "box 130"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424316"
+        },
+        {
+          "tag": "c",
+          "content": "box 131"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424324"
+        },
+        {
+          "tag": "c",
+          "content": "box 132"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424332"
+        },
+        {
+          "tag": "c",
+          "content": "box 133"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424340"
+        },
+        {
+          "tag": "c",
+          "content": "box 134"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424357"
+        },
+        {
+          "tag": "c",
+          "content": "box 135"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424365"
+        },
+        {
+          "tag": "c",
+          "content": "box 136"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424373"
+        },
+        {
+          "tag": "c",
+          "content": "box 137"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424381"
+        },
+        {
+          "tag": "c",
+          "content": "box 138"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424399"
+        },
+        {
+          "tag": "c",
+          "content": "box 139"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424407"
+        },
+        {
+          "tag": "c",
+          "content": "box 140"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424431"
+        },
+        {
+          "tag": "c",
+          "content": "box 141"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424423"
+        },
+        {
+          "tag": "c",
+          "content": "box 142"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424415"
+        },
+        {
+          "tag": "c",
+          "content": "box 143"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424456"
+        },
+        {
+          "tag": "c",
+          "content": "box 144"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424464"
+        },
+        {
+          "tag": "c",
+          "content": "box 145"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424449"
+        },
+        {
+          "tag": "c",
+          "content": "box 146"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424472"
+        },
+        {
+          "tag": "c",
+          "content": "box 147"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424480"
+        },
+        {
+          "tag": "c",
+          "content": "box 148"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424498"
+        },
+        {
+          "tag": "c",
+          "content": "box 149"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424506"
+        },
+        {
+          "tag": "c",
+          "content": "box 150"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424514"
+        },
+        {
+          "tag": "c",
+          "content": "box 151"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424530"
+        },
+        {
+          "tag": "c",
+          "content": "box 152"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424522"
+        },
+        {
+          "tag": "c",
+          "content": "box 153"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424548"
+        },
+        {
+          "tag": "c",
+          "content": "box 154"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424555"
+        },
+        {
+          "tag": "c",
+          "content": "box 155"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424589"
+        },
+        {
+          "tag": "c",
+          "content": "box 157"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424571"
+        },
+        {
+          "tag": "c",
+          "content": "box 158"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424597"
+        },
+        {
+          "tag": "c",
+          "content": "box 159"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424605"
+        },
+        {
+          "tag": "c",
+          "content": "box 160"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424613"
+        },
+        {
+          "tag": "c",
+          "content": "box 161"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424621"
+        },
+        {
+          "tag": "c",
+          "content": "box 162"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424639"
+        },
+        {
+          "tag": "c",
+          "content": "box 163"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424647"
+        },
+        {
+          "tag": "c",
+          "content": "box 164"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424654"
+        },
+        {
+          "tag": "c",
+          "content": "box 165"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424662"
+        },
+        {
+          "tag": "c",
+          "content": "box 166"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424670"
+        },
+        {
+          "tag": "c",
+          "content": "box 167"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424688"
+        },
+        {
+          "tag": "c",
+          "content": "box 168"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424696"
+        },
+        {
+          "tag": "c",
+          "content": "box 169"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424704"
+        },
+        {
+          "tag": "c",
+          "content": "box 170"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424712"
+        },
+        {
+          "tag": "c",
+          "content": "box 171"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424720"
+        },
+        {
+          "tag": "c",
+          "content": "box 172"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424738"
+        },
+        {
+          "tag": "c",
+          "content": "box 173"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424746"
+        },
+        {
+          "tag": "c",
+          "content": "box 174"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424753"
+        },
+        {
+          "tag": "c",
+          "content": "box 175"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424779"
+        },
+        {
+          "tag": "c",
+          "content": "box 176"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424761"
+        },
+        {
+          "tag": "c",
+          "content": "box 177"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424787"
+        },
+        {
+          "tag": "c",
+          "content": "box 178"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424795"
+        },
+        {
+          "tag": "c",
+          "content": "box 179"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424803"
+        },
+        {
+          "tag": "c",
+          "content": "box 180"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424811"
+        },
+        {
+          "tag": "c",
+          "content": "box 181"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424837"
+        },
+        {
+          "tag": "c",
+          "content": "box 182"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424829"
+        },
+        {
+          "tag": "c",
+          "content": "box 183"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424886"
+        },
+        {
+          "tag": "c",
+          "content": "box 184"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424845"
+        },
+        {
+          "tag": "c",
+          "content": "box 185"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424878"
+        },
+        {
+          "tag": "c",
+          "content": "box 186"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424860"
+        },
+        {
+          "tag": "c",
+          "content": "box 187"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424852"
+        },
+        {
+          "tag": "c",
+          "content": "box 188"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424894"
+        },
+        {
+          "tag": "c",
+          "content": "box 189"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112424902"
+        },
+        {
+          "tag": "c",
+          "content": "box 190"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425412"
+        },
+        {
+          "tag": "c",
+          "content": "box 191"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425420"
+        },
+        {
+          "tag": "c",
+          "content": "box 192"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425438"
+        },
+        {
+          "tag": "c",
+          "content": "box 193"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425446"
+        },
+        {
+          "tag": "c",
+          "content": "box 194"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425453"
+        },
+        {
+          "tag": "c",
+          "content": "box 195"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425461"
+        },
+        {
+          "tag": "c",
+          "content": "box 196"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425479"
+        },
+        {
+          "tag": "c",
+          "content": "box 197"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425487"
+        },
+        {
+          "tag": "c",
+          "content": "box 198"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425495"
+        },
+        {
+          "tag": "c",
+          "content": "box 199"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425503"
+        },
+        {
+          "tag": "c",
+          "content": "box 200"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425511"
+        },
+        {
+          "tag": "c",
+          "content": "box 201"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425529"
+        },
+        {
+          "tag": "c",
+          "content": "box 202"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425537"
+        },
+        {
+          "tag": "c",
+          "content": "box 203"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425545"
+        },
+        {
+          "tag": "c",
+          "content": "box 204"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425552"
+        },
+        {
+          "tag": "c",
+          "content": "box 205"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425560"
+        },
+        {
+          "tag": "c",
+          "content": "box 206"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425578"
+        },
+        {
+          "tag": "c",
+          "content": "box 207"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425586"
+        },
+        {
+          "tag": "c",
+          "content": "box 208"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425594"
+        },
+        {
+          "tag": "c",
+          "content": "box 209"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425602"
+        },
+        {
+          "tag": "c",
+          "content": "box 210"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425610"
+        },
+        {
+          "tag": "c",
+          "content": "box 211"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425628"
+        },
+        {
+          "tag": "c",
+          "content": "box 212"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425636"
+        },
+        {
+          "tag": "c",
+          "content": "box 213"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425644"
+        },
+        {
+          "tag": "c",
+          "content": "box 214"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425651"
+        },
+        {
+          "tag": "c",
+          "content": "box 215"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425669"
+        },
+        {
+          "tag": "c",
+          "content": "box 216"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425677"
+        },
+        {
+          "tag": "c",
+          "content": "box 217"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425685"
+        },
+        {
+          "tag": "c",
+          "content": "box 218"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112425693"
+        },
+        {
+          "tag": "c",
+          "content": "box 219"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433087950949"
+        },
+        {
+          "tag": "c",
+          "content": "box 220"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112442821"
+        },
+        {
+          "tag": "c",
+          "content": "box 221"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "i",
+          "content": "33433112442813"
+        },
+        {
+          "tag": "c",
+          "content": "volume 1"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "c",
+          "content": "mao_220540_v01f01_sc.mp3"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "c",
+          "content": "mao_220540_v01f02_sc.mp3"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "c",
+          "content": "mao_220541_v01f01_sc.mp3"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "c",
+          "content": "mao_220541_v01f02_sc.mp3"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "c",
+          "content": "mao_220542_v01f01_sc.mp3"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "c",
+          "content": "mao_220542_v01f02_sc.mp3"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "c",
+          "content": "mao_220543_v01f01_sc.mp3"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "MssCol 22833"
+        },
+        {
+          "tag": "l",
+          "content": "mao82"
+        },
+        {
+          "tag": "c",
+          "content": "mao_220543_v01f02_sc.mp3"
+        },
+        {
+          "tag": "t",
+          "content": "021"
+        },
+        {
+          "tag": "h",
+          "content": "33"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "v",
+          "content": "ARCHV/ARCHV"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "911",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "RL"
+        }
+      ]
+    },
+    {
+      "fieldTag": "_",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "00000npca 2203385Ia 4500",
+      "subfields": null
+    }
+  ]
+}


### PR DESCRIPTION
Improves how we extract OCLC numbers. Currently, oclc numbers in `035 $a` are extracted via the [System control
number](https://github.com/NYPL/nypl-core/blob/8917dc6a29a143997989ef3ee3dfe251cae32dbe/mappings/recap-discovery/field-mapping-bib.json#L309-L311) mapping, which just stores them as they are in generic `dcterms:identifier` statements. This keeps that practice, but uses [an improved mapping](https://github.com/NYPL/nypl-core/pull/80) for OCLC numbers to specifically extract OCLC numbers from both `991 $y` and `035 $a`, for storage as identifiers of type `nypl:Oclc`. Because they're given that type, we strip the "(OCoLC)" prefix wherever found. This will enable us to identify OCLC numbers obtained through 991 or 035 and index them to `idOclc` for efficient matching

https://jira.nypl.org/browse/SCC-2876