### PR TITLE
Fix: ensure oclc identifiers are non-empty

### DIFF
--- a/lib/serializers/bib.js
+++ b/lib/serializers/bib.js
@@ -277,6 +277,8 @@ var fromMarcJson = (object, datasource) => {
         vals = vals.filter((id) => id.includes('(OCoLC)'))
           .map((id) => id.replace(/^\(OCoLC\)/, ''))
       }
+      // Ensure all oclc numbers are non-empty:
+      vals = vals.filter((v) => v)
 
       // Build provo path
       var recordPath = path.marc

--- a/test/bib-marc-test.js
+++ b/test/bib-marc-test.js
@@ -1261,5 +1261,24 @@ describe('Bib Marc Mapping', function () {
           expect(oclcStatements[0].source_record_path).to.eq('035 $a')
         })
     })
+
+    it('should not extract empty OCLC numbers', function () {
+      const bib = BibSierraRecord.from(require('./data/bib-pul-99107030473506421.json'))
+      return bibSerializer.fromMarcJson(bib)
+        .then((statements) => new Bib(statements))
+        .then((bib) => {
+          const oclcStatements = bib.statements('dcterms:identifier')
+            .filter((statement) => statement.object_type === 'nypl:Oclc')
+
+          // This bib has 6 035 varfields, 3 of which have "(OCoLC)" prefixed values. But in one of those, there's no actual identifier (i.e. the content tag is just "(OCoLC)". So we should omit that one.
+          expect(oclcStatements).to.have.lengthOf(2)
+          expect(oclcStatements[0]).to.be.a('object')
+          expect(oclcStatements[0].object_id).to.eq('on1022275496')
+          expect(oclcStatements[0].source_record_path).to.eq('035 $a')
+          expect(oclcStatements[1]).to.be.a('object')
+          expect(oclcStatements[1].object_id).to.eq('1022275496')
+          expect(oclcStatements[1].source_record_path).to.eq('035 $a')
+        })
+    })
   })
 })

--- a/test/data/bib-pul-99107030473506421.json
+++ b/test/data/bib-pul-99107030473506421.json
@@ -1,0 +1,736 @@
+{
+  "id": "99107030473506421",
+  "nyplSource": "recap-pul",
+  "nyplType": "bib",
+  "updatedDate": "2021-12-08T16:02:38-05:00",
+  "createdDate": "2021-12-08T11:03:12-05:00",
+  "deletedDate": null,
+  "deleted": false,
+  "locations": null,
+  "suppressed": false,
+  "lang": {
+    "code": "eng",
+    "name": "English"
+  },
+  "title": "Archivo intervenido : ciudad tomada / [edición y corrección: Iván Vartan Muñoz Cotera].",
+  "author": null,
+  "materialType": {
+    "code": "a",
+    "value": "BOOK/TEXT"
+  },
+  "bibLevel": {
+    "code": "m",
+    "value": "MONOGRAPH"
+  },
+  "publishYear": 2017,
+  "catalogDate": null,
+  "country": {
+    "code": "mx",
+    "name": "Mexico"
+  },
+  "normTitle": null,
+  "normAuthor": null,
+  "standardNumbers": [],
+  "controlNumber": "",
+  "fixedFields": {
+    "24": {
+      "label": "Language",
+      "value": "eng",
+      "display": "English"
+    },
+    "25": {
+      "label": "Skip",
+      "value": "0",
+      "display": null
+    },
+    "26": {
+      "label": "Location",
+      "value": "rcpul",
+      "display": null
+    },
+    "27": {
+      "label": "COPIES",
+      "value": "1",
+      "display": null
+    },
+    "28": {
+      "label": "Cat. Date",
+      "value": null,
+      "display": null
+    },
+    "29": {
+      "label": "Bib Level",
+      "value": "m",
+      "display": "MONOGRAPH"
+    },
+    "30": {
+      "label": "Material Type",
+      "value": "a",
+      "display": "BOOK/TEXT"
+    },
+    "31": {
+      "label": "Bib Code 3",
+      "value": null,
+      "display": null
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "b",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "99107030473506421",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": null,
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2021-12-08T16:02:38Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": "1",
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "6",
+      "display": null
+    },
+    "89": {
+      "label": "Country",
+      "value": "mx",
+      "display": "Mexico"
+    },
+    "98": {
+      "label": "PDATE",
+      "value": null,
+      "display": null
+    },
+    "107": {
+      "label": "MARC Type",
+      "value": " ",
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "fieldTag": null,
+      "marcTag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "(OCoLC)on1022275496"
+        },
+        {
+          "tag": "0",
+          "content": "(uri) http://www.worldcat.org/oclc/1022275496"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "(OCoLC)"
+        },
+        {
+          "tag": "0",
+          "content": "(uri) http://www.worldcat.org/oclc/"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "(109791)0000005374"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "10703047"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "(OCoLC)1022275496"
+        },
+        {
+          "tag": "0",
+          "content": "(uri) http://www.worldcat.org/oclc/1022275496"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "(NjP)10703047-princetondb"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "040",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "H7K"
+        },
+        {
+          "tag": "b",
+          "content": "eng"
+        },
+        {
+          "tag": "e",
+          "content": "rda"
+        },
+        {
+          "tag": "c",
+          "content": "H7K"
+        },
+        {
+          "tag": "d",
+          "content": "OCLCO"
+        },
+        {
+          "tag": "d",
+          "content": "NjP"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "043",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "e-sp---"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "050",
+      "ind1": " ",
+      "ind2": "4",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "N3410.2.P3"
+        },
+        {
+          "tag": "b",
+          "content": "A4 2017"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "245",
+      "ind1": "0",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Archivo intervenido :"
+        },
+        {
+          "tag": "b",
+          "content": "ciudad tomada /"
+        },
+        {
+          "tag": "c",
+          "content": "[edición y corrección: Iván Vartan Muñoz Cotera]."
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "246",
+      "ind1": "3",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Ciudad tomada"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "250",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Primera edición."
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "264",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Saltillo, Caohuila, México :"
+        },
+        {
+          "tag": "b",
+          "content": "Archivo Municipal de Saltillo,"
+        },
+        {
+          "tag": "c",
+          "content": "2017."
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "300",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "44 pages :"
+        },
+        {
+          "tag": "b",
+          "content": "illustrations (some color) ;"
+        },
+        {
+          "tag": "c",
+          "content": "23 cm."
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "336",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "text"
+        },
+        {
+          "tag": "b",
+          "content": "txt"
+        },
+        {
+          "tag": "2",
+          "content": "rdacontent"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "337",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "unmediated"
+        },
+        {
+          "tag": "b",
+          "content": "n"
+        },
+        {
+          "tag": "2",
+          "content": "rdamedia"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "338",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "volume"
+        },
+        {
+          "tag": "b",
+          "content": "nc"
+        },
+        {
+          "tag": "2",
+          "content": "rdacarrier"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "505",
+      "ind1": "8",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Presentación / Olivia Strozzi Galindo -- Archivo Intervenido, Ciudad Tomada / Mauro Marines -- ¿Quienes Son?."
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "546",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "In Spanish."
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "610",
+      "ind1": "2",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Archivo Municipal de Saltillo"
+        },
+        {
+          "tag": "x",
+          "content": "Photograph collections"
+        },
+        {
+          "tag": "v",
+          "content": "Exhibitions."
+        },
+        {
+          "tag": "0",
+          "content": "(uri) http://id.loc.gov/authorities/names/n85123221"
+        },
+        {
+          "tag": "0",
+          "content": "(uri) http://viaf.org/viaf/sourceID/LC|n85123221"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Artists"
+        },
+        {
+          "tag": "z",
+          "content": "Spain"
+        },
+        {
+          "tag": "z",
+          "content": "Palma de Mallorca"
+        },
+        {
+          "tag": "v",
+          "content": "Exhibitions."
+        },
+        {
+          "tag": "0",
+          "content": "(uri) http://id.loc.gov/authorities/subjects/sh85008276"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Art, Spanish"
+        },
+        {
+          "tag": "y",
+          "content": "21st century"
+        },
+        {
+          "tag": "v",
+          "content": "Exhibitions."
+        },
+        {
+          "tag": "0",
+          "content": "http://id.loc.gov/authorities/subjects/sh2009115930"
+        },
+        {
+          "tag": "0",
+          "content": "(uri) http://id.loc.gov/authorities/subjects/sh2009115930"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Muñoz Cotera, Iván Vartan."
+        },
+        {
+          "tag": "0",
+          "content": "http://id.loc.gov/authorities/names/no2018033091"
+        },
+        {
+          "tag": "0",
+          "content": "(uri) http://id.loc.gov/authorities/names/no2018033091"
+        },
+        {
+          "tag": "0",
+          "content": "(uri) http://viaf.org/viaf/sourceID/LC|no2018033091"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "904",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "jar"
+        },
+        {
+          "tag": "b",
+          "content": "a"
+        },
+        {
+          "tag": "h",
+          "content": "m"
+        },
+        {
+          "tag": "c",
+          "content": "b"
+        },
+        {
+          "tag": "e",
+          "content": "20180226"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "902",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "jar"
+        },
+        {
+          "tag": "b",
+          "content": "m"
+        },
+        {
+          "tag": "6",
+          "content": "a"
+        },
+        {
+          "tag": "7",
+          "content": "m"
+        },
+        {
+          "tag": "d",
+          "content": "v"
+        },
+        {
+          "tag": "f",
+          "content": "1"
+        },
+        {
+          "tag": "e",
+          "content": "20180301"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "950",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "c",
+          "content": "2021-08-01 14:08:09 US/Eastern"
+        },
+        {
+          "tag": "b",
+          "content": "2021-07-13 05:50:38 US/Eastern"
+        },
+        {
+          "tag": "a",
+          "content": "false"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "952",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "2021-07-13 09:50:38"
+        },
+        {
+          "tag": "8",
+          "content": "22712690900006421"
+        },
+        {
+          "tag": "b",
+          "content": "Marquand Library"
+        },
+        {
+          "tag": "c",
+          "content": "rcppj: Marquand Remote Storage (ReCAP)"
+        },
+        {
+          "tag": "e",
+          "content": "false"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "901",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "86eea621-cd42-4a07-9f99-814c05c6cd01"
+        },
+        {
+          "tag": "b",
+          "content": "9"
+        },
+        {
+          "tag": "c",
+          "content": "false"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "001",
+      "ind1": null,
+      "ind2": null,
+      "content": "SCSB-8999933",
+      "subfields": null
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "005",
+      "ind1": null,
+      "ind2": null,
+      "content": "20201012200308.0",
+      "subfields": null
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "008",
+      "ind1": null,
+      "ind2": null,
+      "content": "180206s2017    mx a          000 0 eng d",
+      "subfields": null
+    },
+    {
+      "fieldTag": "_",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "01433cam a2200349 i 4500",
+      "subfields": null
+    }
+  ]
+}


### PR DESCRIPTION
Fixes bug where OCLC nums aren't properly validated for non-emptiness, which causes a fatal error.