### PR TITLE
Fix: Skip querying SCSB for empty barcodes

### DIFF
--- a/lib/serializers/item.js
+++ b/lib/serializers/item.js
@@ -130,7 +130,7 @@ const fromMarcJson = async (object, datasource) => {
       }))
     }
 
-    var barcode = null
+    let barcode = null
     if (object.barcode) barcode = { value: object.barcode, path: 'barcode' }
     else if (object.varField('876', ['p']).length) barcode = { value: object.varField('876', ['p'])[0], path: '876 $p' }
     if (barcode) builder.add(fieldMapper.predicateFor('Identifier'), { id: barcode.value, type: 'bf:Barcode' }, 0, { path: barcode.path })
@@ -296,29 +296,30 @@ const fromMarcJson = async (object, datasource) => {
     }
     // Add recap customer code
     let customerCode = null
-    // Disabling SCSB query temporarily 2022-03-04
-    if (false && object.isNyplRecord() && object.location && object.location.code && object.location.code.startsWith('rc')) {
+    let customerCodePath = null
+    if (barcode && barcode.value && object.isNyplRecord() && object.location && object.location.code && object.location.code.startsWith('rc')) {
       const client = await ScsbClient.instance()
-      const barcode = object.barcode || object.varField('876', ['p'])
       const __start = new Date()
-      const response = await client.search({ fieldValue: barcode, fieldName: 'Barcode' })
+      const response = await client.search({ fieldValue: barcode.value, fieldName: 'Barcode' })
       const elapsed = ((new Date()) - __start)
       log.debug({ message: `HTC searchByParam API took ${elapsed}ms`, metric: 'searchByParam-barcode', timeMs: elapsed })
       if (response && response.searchResultRows && response.searchResultRows.length) {
         const results = response.searchResultRows
         if (results && (results.length > 0) && results[0].searchItemResultRows && results[0].searchItemResultRows.length > 0) {
-          log.debug(`${barcode} is a serial item`)
+          log.debug(`${barcode.value} is a serial item`)
           customerCode = results[0].searchItemResultRows[0].customerCode
         } else {
-          log.debug(`${barcode} is a not a serial item`)
+          log.debug(`${barcode.value} is a not a serial item`)
           customerCode = results[0].customerCode
         }
+        customerCodePath = 'scsb query'
       }
     } else if (!object.isNyplRecord()) {
       customerCode = object.varField('900', ['b'])
+      customerCodePath = '900 $b'
     }
     if (customerCode) {
-      builder.add('nypl:recapCustomerCode', { literal: customerCode }, 0, { path: '900 $b' })
+      builder.add('nypl:recapCustomerCode', { literal: customerCode }, 0, { path: customerCodePath })
     }
 
     // Await all resolution promises:


### PR DESCRIPTION
When encountering a ReCAP item with an empty barcode (like
sierra-nypl/22705746 ), skip querying SCSB. Leave recapCustomerCode
empty. Seems some items with ReCAP locations may temporarily have no barcode.