### PR TITLE
Fix parallel extraction

### DIFF
--- a/lib/models/statement.js
+++ b/lib/models/statement.js
@@ -12,6 +12,17 @@ class Statement {
 }
 
 /**
+ *  Returns true if the given object appears to have a valid object.literal
+ */
+const hasValidObjectLiteral = (object) => {
+  // Must have a truthy literal:
+  return object.literal ||
+    // OR, may have a falsey literal if it's declared a boolean:
+    object.type === 'xsd:boolean' ||
+    // OR, may have a falsey literal if it's an empty string (for padding parallel arrays)
+    typeof object.literal === 'string'
+}
+/**
  * A statement builder is an object initialized with a fixed creator_id and
  * base_source_hash, which ensures that an `add` (or `addBlankNode`) calls
  * made upon it use that baseline provenance info in generated statements.
@@ -45,7 +56,7 @@ Statement.builder = (subjectId, creatorId, baseSourceHash) => {
       }
 
       if ((typeof index) !== 'number') throw new Error(predicate + ': no index given')
-      if (!object || (!object.id && !object.literal && object.type !== 'xsd:boolean')) throw new Error(subjectId + ' > ' + predicate + ': invalid object: ' + JSON.stringify(object, null, 2))
+      if (!object.id && !hasValidObjectLiteral(object)) throw new Error(subjectId + ' > ' + predicate + ': invalid object: ' + JSON.stringify(object, null, 2))
       if (!sourceHash || !sourceHash.record_id) throw new Error(predicate + ': no record_id given')
 
       this._addStatement(subjectId, predicate, object, index, sourceHash)
@@ -112,7 +123,7 @@ Statement.builder = (subjectId, creatorId, baseSourceHash) => {
 
       if (object.id) props.object_id = object.id
       if (object.label) props.object_label = object.label
-      if (object.literal || object.type === 'xsd:boolean') props.object_literal = object.literal
+      if (hasValidObjectLiteral(object)) props.object_literal = object.literal
       if (object.type) props.object_type = object.type
       // Should come up with a more compact representation, perhaps, because
       // we have to truncate in some cases:

--- a/lib/serializers/bib.js
+++ b/lib/serializers/bib.js
@@ -28,9 +28,6 @@ var fromMarcJson = (object, datasource) => {
     // Bnumber identifier
     builder.add(fieldMapper.predicateFor('Identifier'), { id: object.id, type: 'nypl:Bnumber' }, 0, { path: 'id' })
 
-    // Title
-    if (object.title) builder.add(fieldMapper.predicateFor('Title'), { literal: object.title }, 0, { path: 'title' })
-
     // Bib Suppression (due to having been deleted, being an OTF record, or
     // actual bib suppression)
     let suppressed = false
@@ -439,24 +436,41 @@ var fromMarcJson = (object, datasource) => {
       })
     })
 
-    // Add various parallel literals:
+    // Loop over *all* parallels
+    Object.values(fieldMapper.data)
+      .filter((mapping) => mapping.isParallelFor)
+      .forEach((fieldMapping) => {
+        // Get the primary mapping:
+        const isParallelFor = fieldMapping.isParallelFor
+        const primaryFieldMapping = fieldMapper.getMapping(isParallelFor)
 
-    const parallelMappings = Object.values(fieldMapper.data).filter(mapping =>
-      mapping.paths && mapping.paths.some(path => path.isParallelFor)
-    )
+        // Get array of all parallel values for this mapping by applying all of
+        // the paths defined in the primary mapping:
+        let parallelValuesWithPath = primaryFieldMapping.paths
+          .filter((path) => path.marc)
+          .reduce((arr, path) => {
+            const subfields = path.subfields || []
+            const _parallelValuesWithMarcTag = object.parallel(path.marc, subfields)
+              .map((value) => {
+                // Keep a reference to the `path` so that we can record the marc
+                // tag, etc
+                return {
+                  path,
+                  value
+                }
+              })
+            return arr.concat(_parallelValuesWithMarcTag)
+          }, [])
 
-    parallelMappings.forEach((fieldMapping) => {
-      fieldMapping.paths.forEach((path) => {
-        const subfields = path.subfields || []
-        const parallelValues = object.parallel(path.isParallelFor, subfields)
-        if (parallelValues && parallelValues.length > 0) {
-          parallelValues.forEach((parallelValue) => {
-            const sourceRecordPath = `880[$u^=${path.isParallelFor}] ${subfields.map((subfield) => `$${subfield}`).join(' ')}`
-            builder.add(fieldMapping.pred, { literal: parallelValue || ' ' }, null, { path: sourceRecordPath })
-          })
-        }
+        // Remove trailing empty statements (because they only serve to pad nonempty statements):
+        parallelValuesWithPath = utils.removeTrailingElementsMatching(parallelValuesWithPath, (v) => v.value === '')
+
+        // Add parallel statements:
+        parallelValuesWithPath.forEach((parallelValue, index) => {
+          const sourceRecordPath = `880[$u^=${parallelValue.path.marc}] ${parallelValue.path.subfields.map((subfield) => `$${subfield}`).join(' ')}`
+          builder.add(fieldMapping.pred, { literal: parallelValue.value || '' }, index, { path: sourceRecordPath })
+        })
       })
-    })
 
     // LDR fields
     if (object.ldr()) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -159,4 +159,21 @@ const distinctSubjectIds = (statements) => {
   )
 }
 
-module.exports = { readJson, capitalize, writeFile, flattenArray, lpad, lineCount, compact, groupBy, coreObjectsMappingByCode, truncate, baseSubjectId, distinctSubjectIds }
+/**
+ * Given an array of objects, removes elements from the end for which the cb
+ * returns `true`
+ *
+ * @example
+ * // The following returns ['one', 'two']:
+ * removeTrailingEmptyStrings(['one', 'two', '', ''], (v) => v === '')
+ *
+ */
+const removeTrailingElementsMatching = (a, cb) => {
+  while (a.length && cb(a[a.length - 1])) {
+    a.pop()
+  }
+
+  return a
+}
+
+module.exports = { readJson, capitalize, writeFile, flattenArray, lpad, lineCount, compact, groupBy, coreObjectsMappingByCode, truncate, baseSubjectId, distinctSubjectIds, removeTrailingElementsMatching }

--- a/test/data/bib-parallels-party.json
+++ b/test/data/bib-parallels-party.json
@@ -1,0 +1,297 @@
+{
+  "id": "123456",
+  "nyplSource": "sierra-nypl",
+  "nyplType": "bib",
+  "title": "Bib asserting lots of characteristics of parallels parsing",
+  "varFields": [
+    {
+      "fieldTag": "d",
+      "marcTag": "600",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-01"
+        },
+        {
+          "tag": "a",
+          "content": "content for 600$a"
+        },
+        {
+          "tag": "d",
+          "content": "content for 600$d"
+        },
+        {
+          "tag": "x",
+          "content": "content for 600$x"
+        },
+        {
+          "tag": "z",
+          "content": "content for 600$z"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "600-01/$1"
+        },
+        {
+          "tag": "a",
+          "content": "parallel content for 600$a"
+        },
+        {
+          "tag": "d",
+          "content": "parallel content for 600$d"
+        },
+        {
+          "tag": "x",
+          "content": "parallel content for 600$x"
+        },
+        {
+          "tag": "z",
+          "content": "parallel content for 600$z"
+        }
+      ]
+    },
+
+    {
+      "fieldTag": "d",
+      "marcTag": "610",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-02"
+        },
+        {
+          "tag": "a",
+          "content": "content for 610$a"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "610-02/$1"
+        },
+        {
+          "tag": "a",
+          "content": "parallel content for 610$a"
+        }
+      ]
+    },
+
+    {
+      "fieldTag": "d",
+      "marcTag": "610",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "content for 610$a (2)"
+        }
+      ]
+    },
+
+    {
+      "fieldTag": "d",
+      "marcTag": "440",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-03"
+        },
+        {
+          "tag": "a",
+          "content": "content for 440$a"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "440-03/$1"
+        },
+        {
+          "tag": "a",
+          "content": "parallel content for 440$a"
+        }
+      ]
+    },
+
+    {
+      "fieldTag": "d",
+      "marcTag": "440",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-04"
+        },
+        {
+          "tag": "a",
+          "content": "content for 440$a (2)"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "440-04/$1"
+        },
+        {
+          "tag": "a",
+          "content": "parallel content for 440$a (2)"
+        }
+      ]
+    },
+
+    {
+      "fieldTag": "d",
+      "marcTag": "490",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "content for 490$a"
+        }
+      ]
+    },
+
+    {
+      "fieldTag": "d",
+      "marcTag": "800",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-05"
+        },
+        {
+          "tag": "a",
+          "content": "content for 800$a"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "800-05/$1"
+        },
+        {
+          "tag": "a",
+          "content": "parallel content for 800$a"
+        }
+      ]
+    },
+
+    {
+      "fieldTag": "d",
+      "marcTag": "260",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "b",
+          "content": "content for 260$b"
+        }
+      ]
+    },
+
+    {
+      "fieldTag": "d",
+      "marcTag": "260",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-06"
+        },
+        {
+          "tag": "b",
+          "content": "content for 260$b (2)"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "260-06/$1"
+        },
+        {
+          "tag": "b",
+          "content": "parallel content for 260$b (2)"
+        }
+      ]
+    },
+
+    {
+      "fieldTag": "d",
+      "marcTag": "260",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "b",
+          "content": "content for 260$b (3)"
+        }
+      ]
+    }
+  ]
+}

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -12,7 +12,32 @@ describe('Utils', function () {
         .map((bnum) => new Statement({ subject_id: bnum, predicate: 'fake:pred', object_id: 'fake:objectid' }))
       const output = utils.distinctSubjectIds(statements)
       expect(output).to.be.a('array')
-      expect(output).to.have.members(['b100', 'b200', 'b300'])
+      expect(output).to.deep.equal(['b100', 'b200', 'b300'])
+    })
+  })
+
+  describe('removeTrailingElementsMatching', () => {
+    it('remove objects with empty .value property', () => {
+      const emptyValue = (v) => v.value === ''
+
+      const input1 = [{ marc: 100, value: '' }, { marc: 101, value: '' }]
+      const res1 = utils.removeTrailingElementsMatching(input1, emptyValue)
+      expect(res1).to.deep.equal([])
+
+      const input2 = [{ marc: 100, value: '' }, { marc: 100, value: 'one' }]
+      const res2 = utils.removeTrailingElementsMatching(input2, emptyValue)
+      expect(res2).to.deep.equal(input2)
+
+      const input3 = [
+        { marc: 100, value: 'one' },
+        { marc: 100, value: 'two' },
+        { marc: 100, value: '' },
+        { marc: 100, value: 'three' },
+        { marc: 100, value: '' },
+        { marc: 100, value: '' }
+      ]
+      const res3 = utils.removeTrailingElementsMatching(input3, emptyValue)
+      expect(res3).to.deep.equal(input3.slice(0, 4))
     })
   })
 })


### PR DESCRIPTION
Changes how parallel fields are looked up to use a new .isParallelFor
property of field mappings, which allows us to define marc paths once in
the primary field and use them when extracting parallel values. This
means 1) we are guaranteed to use the same series of marc paths and in
the same order when extracting parallels as we do when extracting
primary values, and 2) we can ensure that the index of a primary value
corresponds with the index of a parallel value. Also ensures that
blank statements are not used except when necessary to pad values (to
protect index relationships between primary and parallel values). Also,
"blank" values are now always '' instead of ' '.

https://jira.nypl.org/browse/SCC-3071

This depends on [NYPL_CORE_VERSION v1.54a+](https://github.com/NYPL/nypl-core/pull/92)