### PR TITLE
Fix parallel fields for mappings w/out subfields

### DIFF
--- a/lib/models/sierra-record.js
+++ b/lib/models/sierra-record.js
@@ -72,6 +72,8 @@ class SierraRecord {
   /**
    * Get the 880 parallel fields for the given field.
    *
+   * If `subfields` is `null`, indicates all subfields should be used.
+   *
    * If there are no parallel fields, returns []
    *
    * Preserves primary-parallel index relationships, so if there are two
@@ -83,10 +85,21 @@ class SierraRecord {
    * // corresponding bib.literals('245', ..)
    * bib.parallels('245', ['a', 'b'])
    */
-  parallel (field, subfields = []) {
+  parallel (field, subfields = null, opts = {}) {
+    opts = Object.assign({
+      excludedSubfields: []
+    }, opts)
+
     // Although we're querying into 880, first perform identical query against
     // linked tag (e.g. 490), including subfield 6:
-    const primaryValues = this.varField(field, subfields.concat(['6']), { tagSubfields: true })
+    const subfieldsWith6 = Array.isArray(subfields) && subfields.length ? subfields.concat(['6']) : null
+
+    // Primary field mapping may exclude 6, but we need it:
+    const excludedSubfieldsWithout6 = opts.excludedSubfields ? opts.excludedSubfields.filter((subfield) => subfield !== '6') : null
+
+    // Although we're querying into 880, first perform identical query against
+    // linked tag (e.g. 490), including subfield 6:
+    const primaryValues = this.varField(field, subfieldsWith6, { tagSubfields: true, excludedSubfields: excludedSubfieldsWithout6 })
     const parallelValues = primaryValues
       .map((subfieldHash) => {
         // Grab subfield 6:
@@ -103,6 +116,7 @@ class SierraRecord {
 
         let direction = 'ltr'
         const parallelField = this.varField(parallelFieldLink.tag, subfields, {
+          excludedSubfields: opts.excludedSubfields,
           // Use preFilter so that we can filter on raw subfield data:
           preFilter: (block) => {
             // Establish the $u value we're looking for (e.g. 490-01)

--- a/lib/serializers/bib.js
+++ b/lib/serializers/bib.js
@@ -449,8 +449,8 @@ var fromMarcJson = (object, datasource) => {
         let parallelValuesWithPath = primaryFieldMapping.paths
           .filter((path) => path.marc)
           .reduce((arr, path) => {
-            const subfields = path.subfields || []
-            const _parallelValuesWithMarcTag = object.parallel(path.marc, subfields)
+            const subfields = path.subfields
+            const _parallelValuesWithMarcTag = object.parallel(path.marc, subfields, { excludedSubfields: path.excludedSubfields })
               .map((value) => {
                 // Keep a reference to the `path` so that we can record the marc
                 // tag, etc
@@ -467,7 +467,8 @@ var fromMarcJson = (object, datasource) => {
 
         // Add parallel statements:
         parallelValuesWithPath.forEach((parallelValue, index) => {
-          const sourceRecordPath = `880[$u^=${parallelValue.path.marc}] ${parallelValue.path.subfields.map((subfield) => `$${subfield}`).join(' ')}`
+          const subfieldsStatement = (parallelValue.path.subfields || []).map((subfield) => `$${subfield}`).join(' ')
+          const sourceRecordPath = `880[$u^=${parallelValue.path.marc}] ${subfieldsStatement}`
           builder.add(fieldMapping.pred, { literal: parallelValue.value || '' }, index, { path: sourceRecordPath })
         })
       })

--- a/test/bib-marc-test.js
+++ b/test/bib-marc-test.js
@@ -1132,6 +1132,22 @@ describe('Bib Marc Mapping', function () {
           ])
         })
     })
+
+    it('should handle parallel fields correctly when primary mapping is configured with excludedSubfields instead of explicit subfields', function () {
+      var bib = BibSierraRecord.from(require('./data/bib-parallels-party.json'))
+
+      return bibSerializer.fromMarcJson(bib)
+        .then((statements) => new Bib(statements))
+        .then((bib) => {
+          expect(bib.literals('dc:contributor')).to.deep.equal([
+            'content for 710$a content for 710$z'
+          ])
+
+          expect(bib.literals('nypl:parallelContributorLiteral')).to.deep.equal([
+            'parallel content for 710$a parallel content for 710$z'
+          ])
+        })
+    })
   })
 
   describe('Canceled/Invalid identifier extraction', function () {

--- a/test/data/bib-parallels-party.json
+++ b/test/data/bib-parallels-party.json
@@ -282,6 +282,49 @@
 
     {
       "fieldTag": "d",
+      "marcTag": "710",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-07"
+        },
+        {
+          "tag": "a",
+          "content": "content for 710$a"
+        },
+        {
+          "tag": "z",
+          "content": "content for 710$z"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "710-07/$1"
+        },
+        {
+          "tag": "a",
+          "content": "parallel content for 710$a"
+        },
+        {
+          "tag": "z",
+          "content": "parallel content for 710$z"
+        }
+      ]
+    },
+
+    {
+      "fieldTag": "d",
       "marcTag": "260",
       "ind1": "1",
       "ind2": "0",


### PR DESCRIPTION
Fixes bug in parallel field extraction for mappings that don't have
explicit subfields (i.e. mappings typically configured with
excludedSubfields). Previously, when attempting to extract parallel
values for a mapping defined without explicit subfields (which indicates
we want *all* subfields), the parallel field extraction failed to
extract parallel values. This happened because, when running the query
to extract parallel values, we cast the `null` subfields param to `[]`,
causing the query to match *no* subfields. The fix has two parts:
 - Rely on recently added field-mapper-bib changes, which explicitly
 define these parallel mappings with either specific subfields or
 specific "excludedSubfields"
 - Ensure that when `subfields` param is `null`, we handle that
 correctly for parallel field extraction: All subfields should be extracted.

This work depends on [changes to NYPL-Core v1.55](https://github.com/NYPL/nypl-core/pull/93)