### PR TITLE
Fix parallelPublisher > parallelPublisherLiteral

### DIFF
--- a/test/bib-marc-test.js
+++ b/test/bib-marc-test.js
@@ -1126,7 +1126,7 @@ describe('Bib Marc Mapping', function () {
             'content for 260$b (3)'
           ])
 
-          expect(bib.literals('nypl:parallelPublisher')).to.deep.equal([
+          expect(bib.literals('nypl:parallelPublisherLiteral')).to.deep.equal([
             '',
             'parallel content for 260$b (2)'
           ])


### PR DESCRIPTION
We mis-named `parallelPublisherLiteral` as `parallelPublisher` recently. This corrects it in this app to fix a broken test.