### PR TITLE
Extract two new Aeon item and bib properties for Aeon linking

### DIFF
--- a/config/test.env
+++ b/config/test.env
@@ -1,0 +1,6 @@
+LOGLEVEL=error
+INDEX_DOCUMENT_STREAM_NAME=IndexDocumentQueue-qa
+INDEX_DOCUMENT_SCHEMA_NAME=IndexDocumentQueue
+NYPL_API_BASE_URL=https://example.com/
+NYPL_CORE_VERSION=master
+AEON_BASE_URLS=https://specialcollections.nypl.org,https://nypl-aeon-test.aeon.atlas-sys.com

--- a/lib/serializers/bib.js
+++ b/lib/serializers/bib.js
@@ -475,6 +475,19 @@ var fromMarcJson = (object, datasource) => {
         })
       })
 
+    if (process.env.AEON_BASE_URLS) {
+      // Add Aeon URL:
+      const aeonUrl = object.varField('856', 'u')
+        .filter((url) => {
+          return (process.env.AEON_BASE_URLS || '').split(',')
+            .some((aeonBaseUrl) => url.startsWith(aeonBaseUrl))
+        })
+        .shift()
+      if (aeonUrl) {
+        builder.add('nypl:aeonUrl', { literal: aeonUrl }, 0, { path: '856 $u' })
+      }
+    }
+
     // LDR fields
     if (object.ldr()) {
       if (object.ldr().bibLevel) {

--- a/lib/serializers/item.js
+++ b/lib/serializers/item.js
@@ -308,6 +308,17 @@ const fromMarcJson = async (object, datasource) => {
       builder.add('nypl:recapCustomerCode', { literal: customerCode }, 0, { path: customerCodePath })
     }
 
+    // Aeon eligibility is determined by presence of a fieldTag 'x' field that
+    // starts "AEON eligible"
+    const aeonSiteCode = (object.fieldTag('x') || [])
+      .filter((noteContent) => noteContent.startsWith('AEON eligible'))
+      .map((noteContent) => noteContent.replace(/^AEON eligible /, ''))
+      .shift()
+
+    if (aeonSiteCode) {
+      builder.add('nypl:aeonSiteCode', { literal: aeonSiteCode }, 0, { path: 'fieldTag x' })
+    }
+
     // Await all resolution promises:
     return Promise.all(promises).then(() => {
       // Determine requestability

--- a/test/bib-marc-test.js
+++ b/test/bib-marc-test.js
@@ -1385,4 +1385,21 @@ describe('Bib Marc Mapping', function () {
         })
     })
   })
+
+  describe('Add Aeon URL', () => {
+    it('should add aeonURL', async () => {
+      let bib = BibSierraRecord.from(require('./data/bib-10204814.json'))
+      const statements = await bibSerializer.fromMarcJson(bib)
+      bib = new Bib(statements)
+      expect(bib.statement('nypl:aeonUrl')).to.be.a('object')
+      expect(bib.statement('nypl:aeonUrl').object_literal).to.eq('https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Something+concerning+Nobody.&Site=SASAR&CallNumber=Arents+S+0937&ItemPlace=London,&ItemPublisher=Printed+for+Robert+Scholey,&Date=1814.&Site=SASAR')
+    })
+
+    it('should not mistake non-Aeon URLs as aeonURL', async () => {
+      let bib = BibSierraRecord.from(require('./data/bib-20549111.json'))
+      const statements = await bibSerializer.fromMarcJson(bib)
+      bib = new Bib(statements)
+      expect(bib.statement('nypl:aeonUrl')).to.be.a('undefined')
+    })
+  })
 })

--- a/test/item-marc-test.js
+++ b/test/item-marc-test.js
@@ -433,4 +433,14 @@ describe('Item Marc Mapping', function () {
       expect(!item.statements['nypl:recapCustomerCode'])
     })
   })
+
+  describe('Add Aeon Site Code', () => {
+    it('should add aeonSiteCode', async () => {
+      let item = ItemSierraRecord.from(require('./data/item-aeon-eligible.json'))
+      const statements = await itemSerializer.fromMarcJson(item)
+      item = new Item(statements)
+      expect(item.statement('nypl:aeonSiteCode')).to.be.a('object')
+      expect(item.statement('nypl:aeonSiteCode').object_literal).to.eq('SCHRB')
+    })
+  })
 })

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -1,0 +1,5 @@
+const dotenv = require('dotenv')
+
+before(() => {
+  dotenv.config({ path: './config/test.env' })
+})


### PR DESCRIPTION
Extract item.aeonSiteCode and bib.aeonUrl from item and bib
documents. Rely on discovery-store-poster downstream to knit them
together into an item.aeonUrl property.

Depends on NYPL-Core v1.63

https://jira.nypl.org/browse/SCC-3159