### PR TITLE
Fix date parse batching and filtering

### DIFF
--- a/lib/date-parse/index.js
+++ b/lib/date-parse/index.js
@@ -1,4 +1,5 @@
 const AWS = require('aws-sdk')
+const log = require('loglevel')
 const SierraItem = require('../models/item-sierra-record')
 
 const { preparsingObjects, returnOneYear } = require('./preparsingObjects')
@@ -66,7 +67,16 @@ const preparse = function (dates) {
     })
     return date
   })
+    // After applying "preparsing" corrections to the data, remove anything
+    // that doesn't have at least a four digit year (minimum for a parsable
+    // date)
+    .filter(_has4DigitYear)
 }
+
+/**
+ * Returns true if string appears to have at least one 4-digit year
+ */
+const _has4DigitYear = (d) => /\b\d{4}\b/.test(d)
 
 /**
  *
@@ -120,18 +130,19 @@ const _parseDates = async function (dates) {
  */
 
 const timeTwist = async (preparsedDates) => {
-  const payloadStr = JSON.stringify({
-    path: '/',
-    body: JSON.stringify({ dates: preparsedDates })
-  })
-  const params = {
-    FunctionName: 'DateParser-qa',
-    Payload: payloadStr
-  }
   const preparsedDatesBatches = batchDates(1000, preparsedDates)
 
+  log.debug(`Invoking lambda with ${preparsedDatesBatches.length} batches of ${preparsedDates.length} dates`)
   const timetwistedDates = await Promise.all(preparsedDatesBatches.map(async (batch) => {
+    const params = {
+      FunctionName: 'DateParser-qa',
+      Payload: JSON.stringify({
+        path: '/',
+        body: JSON.stringify({ dates: batch })
+      })
+    }
     try {
+      log.debug(`  Invoking lambda with ${params.Payload}`)
       const { Payload } = await lambdaClient().invoke(params).promise()
       // Extract date information from payload
       const payloadParsed = batch
@@ -145,6 +156,7 @@ const timeTwist = async (preparsedDates) => {
       console.error(error)
     }
   }))
+  log.debug('/Finished invoking dateparser lambda')
   return timetwistedDates.flat()
 }
 
@@ -164,4 +176,4 @@ const filterNulls = (rangesArray, preparsedDates) => {
   })
 }
 
-module.exports = { parseDatesAndCache, checkCache, private: { _parseDates } }
+module.exports = { parseDatesAndCache, checkCache, private: { _parseDates, _has4DigitYear } }

--- a/test/date-parse-test.js
+++ b/test/date-parse-test.js
@@ -1,6 +1,6 @@
 /* global describe it */
 const expect = require('chai').expect
-const { parseDatesAndCache, checkCache, private: { _parseDates } } = require('../lib/date-parse')
+const { parseDatesAndCache, checkCache, private: { _parseDates, _has4DigitYear } } = require('../lib/date-parse')
 const serialBibs = require('./data/date-parse-bibs/v-bibs.json')
 const mixedBibs = require('./data/date-parse-bibs/mixed-bibs.json')
 
@@ -123,6 +123,23 @@ describe('dateParser Lambda', () => {
       const fieldtagv = 'Mar. 1969-Winter 1970'
       const [parsed] = await _parseDates(fieldtagv)
       expect(parsed).to.deep.equal([['1969-03-01', '1970-03-20']])
+    })
+  })
+
+  describe.only('_has4DigitYear', () => {
+    it('should identify string with a 4 digit year', () => {
+      expect(_has4DigitYear('some stuff 1998 other stuff')).to.eq(true)
+      expect(_has4DigitYear('1998 other stuff')).to.eq(true)
+      expect(_has4DigitYear('some stuff 1998')).to.eq(true)
+      expect(_has4DigitYear('1998')).to.eq(true)
+      expect(_has4DigitYear('1998-1999')).to.eq(true)
+      expect(_has4DigitYear('-1999')).to.eq(true)
+      expect(_has4DigitYear('2022.10')).to.eq(true)
+    })
+
+    it('should fail string with a number that is not 4 digits', () => {
+      expect(_has4DigitYear('some stuff 123')).to.eq(false)
+      expect(_has4DigitYear('some stuff 12345')).to.eq(false)
     })
   })
 })

--- a/test/date-parse-test.js
+++ b/test/date-parse-test.js
@@ -126,7 +126,7 @@ describe('dateParser Lambda', () => {
     })
   })
 
-  describe.only('_has4DigitYear', () => {
+  describe('_has4DigitYear', () => {
     it('should identify string with a 4 digit year', () => {
       expect(_has4DigitYear('some stuff 1998 other stuff')).to.eq(true)
       expect(_has4DigitYear('1998 other stuff')).to.eq(true)


### PR DESCRIPTION
Fix two aspects of date parsing:
 - Fix bug where batches of dates sent to date parser are actually the just the whole set of dates pre-batching, sent multiple times
 - Add filter to only send dates to the date parser lambda if they appear to have parsable dates (i.e. have 4 digit year)