### PR TITLE
Scc 3094 create fake checkin card items for checkin cards

### DIFF
--- a/lib/date-parse/date-utils.js
+++ b/lib/date-parse/date-utils.js
@@ -1,0 +1,44 @@
+/**
+ *
+ * Given a date string, returns an ISO8601 formatting of the date
+ *
+ * Minimal season support
+ */
+const parseCheckinCardDate = (s) => {
+  const seasonMap = [
+    {
+      match: /\bSum(\.|mer)?\b/,
+      replace: 'Jul.'
+    },
+    {
+      match: /\bSpr(\.|ing)?\b/,
+      replace: 'Apr.'
+    },
+    {
+      match: /\b(Fall|Aut(\.|umn)?)\b/,
+      replace: 'Oct.'
+    },
+    {
+      match: /\bWin(\.|ter)?\b/,
+      replace: 'Jan.'
+    }
+  ]
+  seasonMap.forEach((rule) => {
+    if (rule.match.test(s)) {
+      s = s.replace(rule.match, rule.replace)
+    }
+  })
+
+  let date
+  try {
+    date = new Date(s)
+    return date.toISOString().replace(/T.+/, '')
+  } catch (e) {
+    console.error(`DateParse: DateUtils: Could not parse '${s}' as date`)
+    return null
+  }
+}
+
+module.exports = {
+  parseCheckinCardDate
+}

--- a/lib/holding-status-mapping.js
+++ b/lib/holding-status-mapping.js
@@ -1,0 +1,18 @@
+const notAvailable = { id: 'status:na', label: 'Not Available (ReCAP' }
+const available = { id: 'status:a', label: 'Available' }
+const bindery = { id: 'status:i', label: 'At bindery' }
+
+module.exports = {
+  A: available,
+  B: notAvailable,
+  E: notAvailable,
+  L: notAvailable,
+  M: { id: 'status:m', label: 'Missing' },
+  N: notAvailable,
+  O: notAvailable,
+  P: available,
+  R: { id: 'status:w', label: 'Withdrawn' },
+  S: bindery,
+  T: bindery,
+  U: notAvailable
+}

--- a/lib/nyplDataApi.js
+++ b/lib/nyplDataApi.js
@@ -27,7 +27,7 @@ const bib = (source, id) => {
 }
 
 const holding = (id) => {
-  return client().get(`holdings/${id}`)[0]
+  return client().get(`holdings/${id}`)
 }
 
 module.exports = { bib, item, holding }

--- a/lib/serializers/holding.js
+++ b/lib/serializers/holding.js
@@ -102,6 +102,8 @@ const fromMarcJson = (object) => {
 
     // Check In Boxes
     // This is a blank node that represents a series of fields drawn from check-in card records
+    // Additionally, loops through checkin-card creating faux item for each checkin-card box.
+    let checkInCardItemBuilder
     object.checkInCards.forEach((box, index) => {
       // Create coverage string
       let coverage = ''
@@ -129,7 +131,7 @@ const fromMarcJson = (object) => {
       builder.addBlankNode(fieldMapper.predicateFor('Check In Box'), blankNode, index, { path: 'checkInCards' })
 
       const checkInCardItemId = `i-holding${holdingId}-${index}`
-      const checkInCardItemBuilder = Statement.builder(checkInCardItemId, Creator.CORE_SERIALIZER.id, { id: datasource.id, record_id: object.id })
+      checkInCardItemBuilder = Statement.builder(checkInCardItemId, Creator.CORE_SERIALIZER.id, { id: datasource.id, record_id: object.id })
 
       checkInCardItemBuilder.add('rdfs:type', { id: 'nypl:CheckinCarditem' })
       checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Enumeration Chronology'), { literal: coverage })
@@ -145,9 +147,10 @@ const fromMarcJson = (object) => {
       checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Volume Raw'), { literal: box.enumeration.enumeration })
       checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Volume Range'), { literal: parseVolume(box.enumeration.enumeration) })
       checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Date Range'), { literal: [box.start_date, box.end_date] })
-      checkInCardItemBuilder.add(fieldMapper.predicateFor('Status', holdingStatusMapping[box.status.code], index))
+      checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Availability'), holdingStatusMapping[box.status.code], index)
     })
-    return Promise.resolve(builder.statements)
+    const stmts = checkInCardItemBuilder ? builder.statements.concat(checkInCardItemBuilder.statements) : builder.statements
+    return Promise.resolve(stmts)
   } catch (e) {
     return Promise.reject(e)
   }

--- a/lib/serializers/holding.js
+++ b/lib/serializers/holding.js
@@ -104,8 +104,7 @@ const fromMarcJson = (object) => {
     // This is a blank node that represents a series of fields drawn from check-in card records
     // Additionally, loops through checkin-card creating faux item for each checkin-card box.
     let checkInCardItemBuilder
-    let holdingAndCheckInCardItemStatements = builder.statements
-    object.checkInCards.map((box, index) => {
+    const checkInCardItemStatements = object.checkInCards.map((box, index) => {
       // Create coverage string
       let coverage = ''
       // Get any enumeration associated with this box
@@ -149,9 +148,11 @@ const fromMarcJson = (object) => {
       checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Volume Range'), { literal: parseVolume(box.enumeration.enumeration) })
       checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Date Range'), { literal: [box.start_date, box.end_date] })
       checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Availability'), holdingStatusMapping[box.status.code], index)
-      holdingAndCheckInCardItemStatements = holdingAndCheckInCardItemStatements.concat(checkInCardItemBuilder.statements)
+
+      return checkInCardItemBuilder.statements
     })
-    return Promise.resolve(holdingAndCheckInCardItemStatements)
+    const state = builder.statements.concat(checkInCardItemStatements.flat())
+    return Promise.resolve(state)
   } catch (e) {
     return Promise.reject(e)
   }

--- a/lib/serializers/holding.js
+++ b/lib/serializers/holding.js
@@ -104,7 +104,8 @@ const fromMarcJson = (object) => {
     // This is a blank node that represents a series of fields drawn from check-in card records
     // Additionally, loops through checkin-card creating faux item for each checkin-card box.
     let checkInCardItemBuilder
-    object.checkInCards.forEach((box, index) => {
+    let holdingAndCheckInCardItemStatements = builder.statements
+    object.checkInCards.map((box, index) => {
       // Create coverage string
       let coverage = ''
       // Get any enumeration associated with this box
@@ -130,7 +131,7 @@ const fromMarcJson = (object) => {
 
       builder.addBlankNode(fieldMapper.predicateFor('Check In Box'), blankNode, index, { path: 'checkInCards' })
 
-      const checkInCardItemId = `i-holding${holdingId}-${index}`
+      const checkInCardItemId = `i-${holdingId}-${index}`
       checkInCardItemBuilder = Statement.builder(checkInCardItemId, Creator.CORE_SERIALIZER.id, { id: datasource.id, record_id: object.id })
 
       checkInCardItemBuilder.add('rdfs:type', { id: 'nypl:CheckinCarditem' })
@@ -148,9 +149,9 @@ const fromMarcJson = (object) => {
       checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Volume Range'), { literal: parseVolume(box.enumeration.enumeration) })
       checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Date Range'), { literal: [box.start_date, box.end_date] })
       checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Availability'), holdingStatusMapping[box.status.code], index)
+      holdingAndCheckInCardItemStatements = holdingAndCheckInCardItemStatements.concat(checkInCardItemBuilder.statements)
     })
-    const stmts = checkInCardItemBuilder ? builder.statements.concat(checkInCardItemBuilder.statements) : builder.statements
-    return Promise.resolve(stmts)
+    return Promise.resolve(holdingAndCheckInCardItemStatements)
   } catch (e) {
     return Promise.reject(e)
   }

--- a/lib/serializers/holding.js
+++ b/lib/serializers/holding.js
@@ -7,6 +7,7 @@ const Datasource = require('../models/datasource')
 const buildFieldMapper = require('../field-mapper')
 const { parseVolume } = require('../volume-parser')
 const holdingStatusMapping = require('../holding-status-mapping')
+const dateUtils = require('../date-parse/date-utils')
 
 const log = require('loglevel')
 
@@ -134,12 +135,7 @@ const fromMarcJson = (object) => {
       checkInCardItemBuilder = Statement.builder(checkInCardItemId, Creator.CORE_SERIALIZER.id, { id: datasource.id, record_id: object.id })
 
       checkInCardItemBuilder.add('rdfs:type', { id: 'nypl:CheckinCarditem' })
-      checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Access message'), { id: 'accessMessage: 1', label: 'Use in library' }, index)
-
-      if (box.enumeration.enumeration) {
-        checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Volume Raw'), { literal: box.enumeration.enumeration })
-        checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Enumeration Chronology'), { literal: coverage })
-      }
+      checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Access message'), { id: 'accessMessage:1', label: 'Use in library' }, index)
       if (formatLiteral) {
         checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Format'), { literal: formatLiteral })
       }
@@ -152,13 +148,39 @@ const fromMarcJson = (object) => {
           checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Call number'), { literal: callNum }, index)
         }
       })
-      checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Volume Range'), { literal: parseVolume(box.enumeration.enumeration) })
-      if (box.start_date && box.end_date) {
-        checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Date Range'), { literal: [box.start_date, box.end_date] })
+      if (box.enumeration.enumeration) {
+        checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Volume Raw'), { literal: box.enumeration.enumeration })
+        const volumeRanges = parseVolume(box.enumeration.enumeration)
+        // Does enumeration contain parsable volume ranges?
+        if (volumeRanges && volumeRanges.length) {
+          volumeRanges.forEach((volumeRange) => {
+            checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Volume Range'), { literal: volumeRange })
+          })
+        }
       }
-      if (box.status && box.status.code && holdingStatusMapping[box.status.code]) {
-        checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Availability'), holdingStatusMapping[box.status.code], index)
+      if (box.start_date || box.endDate) {
+        let dateRange = []
+        if (box.start_date) {
+          dateRange[0] = dateUtils.parseCheckinCardDate(box.start_date)
+        }
+        if (box.end_date) {
+          dateRange[1] = dateUtils.parseCheckinCardDate(box.end_date)
+        }
+        if (!dateRange[1]) {
+          // For now, if no end-date is specified, just use start-date:
+          dateRange[1] = dateRange[0]
+        }
+
+        // Remove nulls:
+        dateRange = dateRange.filter((d) => d)
+        // Insist on two-part range (i.e. no open ended ranges):
+        if (dateRange.length === 2) {
+          // Ensure bad parsing or data doesn't produce a reversed range:
+          dateRange = dateRange.sort((d1, d2) => d1 < d2 ? -1 : 1)
+          checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Date Range'), { literal: dateRange })
+        }
       }
+      checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Availability'), holdingStatusMapping[box.status.code], index)
 
       return checkInCardItemBuilder.statements
     })

--- a/lib/serializers/holding.js
+++ b/lib/serializers/holding.js
@@ -148,6 +148,7 @@ const fromMarcJson = (object) => {
           checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Call number'), { literal: callNum }, index)
         }
       })
+      checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Enumeration Chronology'), { literal: coverage })
       if (box.enumeration.enumeration) {
         checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Volume Raw'), { literal: box.enumeration.enumeration })
         const volumeRanges = parseVolume(box.enumeration.enumeration)

--- a/lib/serializers/holding.js
+++ b/lib/serializers/holding.js
@@ -5,12 +5,15 @@ const Statement = require('../models/statement')
 const Creator = require('../models/creator')
 const Datasource = require('../models/datasource')
 const buildFieldMapper = require('../field-mapper')
+const { parseVolume } = require('../volume-parser')
+const holdingStatusMapping = require('../holding-status-mapping')
 
 const log = require('loglevel')
 
 const fromMarcJson = (object) => {
   try {
     const fieldMapper = buildFieldMapper('holding', null)
+    const itemFieldMapper = buildFieldMapper('item', null)
 
     const holdingId = object.prefixedId()
 
@@ -37,7 +40,7 @@ const fromMarcJson = (object) => {
       // It's suppressed so return the minimal record we've built so far:
       return Promise.resolve(builder.statements)
 
-    // Not suppressed: Record that and continue building the serialization:
+      // Not suppressed: Record that and continue building the serialization:
     } else {
       builder.add(fieldMapper.predicateFor('Suppressed'), { literal: false, type: 'xsd:boolean' }, 0)
     }
@@ -49,7 +52,7 @@ const fromMarcJson = (object) => {
     const shelfMarkMarc = shelfMarkMapping.paths[0].marc
     const shelfMarkSubfields = shelfMarkMapping.paths[0].subfields
 
-    const callNumFields = object.varField(shelfMarkMarc, shelfMarkSubfields)
+    let callNumFields = object.varField(shelfMarkMarc, shelfMarkSubfields)
     callNumFields.forEach((callNum, index) => {
       const fieldPath = `${shelfMarkMarc} ${shelfMarkSubfields.map((s) => `$${s}`).join(' ')}`
 
@@ -82,10 +85,9 @@ const fromMarcJson = (object) => {
 
     // Format
     // Drawn from the 843$a field, or if not found there potentially in the i fieldTag
-    if (object.varField('843', ['a']).length > 0) {
-      builder.add(fieldMapper.predicateFor('Format'), { literal: object.varField('843', ['a'])[0] }, 0, { path: '843 $a' })
-    } else if (object.fieldTag('i') && object.fieldTag('i').length > 0) {
-      builder.add(fieldMapper.predicateFor('Format'), { literal: object.fieldTag('i')[0] }, 0, { path: 'fieldTag i' })
+    const formatLiteral = object.varField('843', ['a']).length > 0 ? object.varField('843', ['a'])[0] : object.fieldTag('i') && object.fieldTag('i').length > 0 ? object.fieldTag('i')[0] : null
+    if (formatLiteral) {
+      builder.add(fieldMapper.predicateFor('Format'), { literal: formatLiteral })
     }
 
     // Note
@@ -125,8 +127,26 @@ const fromMarcJson = (object) => {
       }
 
       builder.addBlankNode(fieldMapper.predicateFor('Check In Box'), blankNode, index, { path: 'checkInCards' })
-    })
 
+      const checkInCardItemId = `i-holding${holdingId}-${index}`
+      const checkInCardItemBuilder = Statement.builder(checkInCardItemId, Creator.CORE_SERIALIZER.id, { id: datasource.id, record_id: object.id })
+
+      checkInCardItemBuilder.add('rdfs:type', { id: 'nypl:CheckinCarditem' })
+      checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Enumeration Chronology'), { literal: coverage })
+      checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Access message'), { id: 'accessMessage: 1', label: 'Use in library' }, index)
+      checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Format'), { literal: formatLiteral })
+      callNumFields = object.varField(shelfMarkMarc, shelfMarkSubfields)
+      callNumFields.forEach((callNum, index) => {
+        // Sierra seems to put these '|h' prefixes on callnumbers; strip 'em
+        if (callNum) callNum = callNum.replace(/^\|h/, '')
+
+        checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Call number'), { literal: callNum }, index)
+      })
+      checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Volume Raw'), { literal: box.enumeration.enumeration })
+      checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Volume Range'), { literal: parseVolume(box.enumeration.enumeration) })
+      checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Date Range'), { literal: [box.start_date, box.end_date] })
+      checkInCardItemBuilder.add(fieldMapper.predicateFor('Status', holdingStatusMapping[box.status.code], index))
+    })
     return Promise.resolve(builder.statements)
   } catch (e) {
     return Promise.reject(e)

--- a/lib/serializers/holding.js
+++ b/lib/serializers/holding.js
@@ -134,20 +134,31 @@ const fromMarcJson = (object) => {
       checkInCardItemBuilder = Statement.builder(checkInCardItemId, Creator.CORE_SERIALIZER.id, { id: datasource.id, record_id: object.id })
 
       checkInCardItemBuilder.add('rdfs:type', { id: 'nypl:CheckinCarditem' })
-      checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Enumeration Chronology'), { literal: coverage })
       checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Access message'), { id: 'accessMessage: 1', label: 'Use in library' }, index)
-      checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Format'), { literal: formatLiteral })
+
+      if (box.enumeration.enumeration) {
+        checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Volume Raw'), { literal: box.enumeration.enumeration })
+        checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Enumeration Chronology'), { literal: coverage })
+      }
+      if (formatLiteral) {
+        checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Format'), { literal: formatLiteral })
+      }
       callNumFields = object.varField(shelfMarkMarc, shelfMarkSubfields)
       callNumFields.forEach((callNum, index) => {
         // Sierra seems to put these '|h' prefixes on callnumbers; strip 'em
-        if (callNum) callNum = callNum.replace(/^\|h/, '')
+        if (callNum) {
+          callNum = callNum.replace(/^\|h/, '')
 
-        checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Call number'), { literal: callNum }, index)
+          checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Call number'), { literal: callNum }, index)
+        }
       })
-      checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Volume Raw'), { literal: box.enumeration.enumeration })
       checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Volume Range'), { literal: parseVolume(box.enumeration.enumeration) })
-      checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Date Range'), { literal: [box.start_date, box.end_date] })
-      checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Availability'), holdingStatusMapping[box.status.code], index)
+      if (box.start_date && box.end_date) {
+        checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Date Range'), { literal: [box.start_date, box.end_date] })
+      }
+      if (box.status && box.status.code && holdingStatusMapping[box.status.code]) {
+        checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Availability'), holdingStatusMapping[box.status.code], index)
+      }
 
       return checkInCardItemBuilder.statements
     })

--- a/lib/serializers/item.js
+++ b/lib/serializers/item.js
@@ -182,21 +182,24 @@ const fromMarcJson = async (object, datasource, bib) => {
       builder.add(fieldMapper.predicateFor('Call number'), { literal: callnum.value }, 0, { path: callnum.path })
     }
 
-    const fieldtagv = object.fieldTag('v')
-    const parsedVols = parseVolume(fieldtagv)
-    if (parsedVols) {
-      // Add each identified volume range (usually just one) as a statement:
-      parsedVols.forEach((vol) => {
-        builder.add(fieldMapper.predicateFor('Volume Range'), { literal: vol }, null, { path: 'fieldTag v' })
-      })
-    }
+    let fieldtagv = object.fieldTag('v')
+    if (fieldtagv.length === 1) {
+      fieldtagv = fieldtagv[0]
+      const parsedVols = parseVolume(fieldtagv)
+      if (parsedVols) {
+        // Add each identified volume range (usually just one) as a statement:
+        parsedVols.forEach((vol) => {
+          builder.add(fieldMapper.predicateFor('Volume Range'), { literal: vol }, null, { path: 'fieldTag v' })
+        })
+      }
 
-    const parsedDates = parseDate.checkCache(fieldtagv)
-    if (parsedDates) {
-      // Add each parsed date range (usually just one) as a statement:
-      parsedDates.forEach((date) => {
-        if (date !== null) builder.add(fieldMapper.predicateFor('Date Range'), { literal: date }, null, { path: 'fieldTag v' })
-      })
+      const parsedDates = parseDate.checkCache(fieldtagv)
+      if (parsedDates) {
+        // Add each parsed date range (usually just one) as a statement:
+        parsedDates.forEach((date) => {
+          if (date !== null) builder.add(fieldMapper.predicateFor('Date Range'), { literal: date }, null, { path: 'fieldTag v' })
+        })
+      }
     }
 
     // Availability

--- a/lib/volume-parser.js
+++ b/lib/volume-parser.js
@@ -3,32 +3,35 @@ exports.parseVolume = (fieldTagV) => {
     // Captured values are the numbers found after volume/vol/v, no, bd, and reel/r with or without periods
     // (?:^|\s|-) is a non-capturing group to ensure that we are not matching on parts of other words
     /(?:^|\s|-)(?:volume|vol\.?|v\.?)\s?(\d*)[-|/]?(\d*)?/gi,
-    /(?:^|\s|-)(?:no\.?)\s?(\d*)[-|/]?(\d*)?/gi,
     /(?:^|\s|-)(?:bd\.?)\s?(\d*)[-|/]?(\d*)?/gi,
     /(?:^|\s|-)(?:reel|r\.?)\s?(\d*)[-|/]?(\d*)?/gi,
-    /jaarg\.?/gi
+    /jaarg\.?/gi,
+    /(?:^|\s|-)(?:no\.?)\s?(\d*)[-|/]?(\d*)?/gi
   ]
 
-  let regExpIndex = 0
-  const volumes = []
-  // If volumes is not populated yet, and there are still more regular expressions to try, try them
-  while (volumes.length === 0 && regExpIndex < (regExp.length - 1)) {
-    let matches
-    // This is some JS regex magic that I found on MDN to iterate through global matches.
-    while ((matches = regExp[regExpIndex].exec(fieldTagV)) !== null) {
-      // First element is match group, we don't want that
-      let match = matches.slice(1)
-      // Eliminate null values and convert from string to int
-      match = match
-        .filter(num => num)
-        .map((num) => parseInt(num, 10))
-      // [6] ==> [6,6]
-      if (match.length === 1) match[1] = match[0]
-      // [6,7,8] ==> [6,8]
-      if (match.length > 2) match = [match[0], match[match.length - 1]]
-      volumes.push(match)
+  let volumesFound = false
+  let volumes
+  // loop through regular expressions
+  regExp.forEach((exp) => {
+    // we only want to match on one type of regular expression to avoid
+    // weirdness with field tag vs that have vol. and no.
+    if (!volumesFound) {
+      // convert regexp iterator into array so we can get successive matches a
+      const matches = [...fieldTagV.matchAll(exp)]
+      volumes = matches.reduce((vols, match) => {
+        // extract the numbers from regex array-like object
+        match = match.slice(1, 3)
+          // Eliminate null valuesconvert from string to int
+          .filter(m => m)
+          // convert from string to int
+          .map(m => parseInt(m, 10))
+        if (match.length) volumesFound = true
+        // [6,7,8] ==> [6,8]
+        if (match.length > 2) match = [match[0], match[match.length - 1]]
+        if (match.length === 1) match = [match[0], match[0]]
+        return [...vols, match]
+      }, [])
     }
-    regExpIndex++
-  }
+  })
   return volumes
 }

--- a/lib/volume-parser.js
+++ b/lib/volume-parser.js
@@ -1,3 +1,7 @@
+/**
+ * Given a fieldtag v value, returns an array of ranges, each represented as a
+ * two element array
+ */
 exports.parseVolume = (fieldTagV) => {
   const regExp = [
     // Captured values are the numbers found after volume/vol/v, no, bd, and reel/r with or without periods
@@ -5,8 +9,12 @@ exports.parseVolume = (fieldTagV) => {
     /(?:^|\s|-)(?:volume|vol\.?|v\.?)\s?(\d*)[-|/]?(\d*)?/gi,
     /(?:^|\s|-)(?:bd\.?)\s?(\d*)[-|/]?(\d*)?/gi,
     /(?:^|\s|-)(?:reel|r\.?)\s?(\d*)[-|/]?(\d*)?/gi,
-    /jaarg\.?/gi,
-    /(?:^|\s|-)(?:no\.?)\s?(\d*)[-|/]?(\d*)?/gi
+    /(?:^|\s|-)(?:no\.?)\s?(\d*)[-|/]?(\d*)?/gi,
+    // FIXME: This is never evaluated:
+    /jaarg\.?/gi //,
+
+    // FIXME: If the "fieldTagV" value is just "21", we should accept that as a vol statement
+    // /\b(\d{1,3})\b/
   ]
 
   let volumesFound = false
@@ -34,4 +42,5 @@ exports.parseVolume = (fieldTagV) => {
     }
   })
   return volumes
+    .filter((range) => Array.isArray(range) && range.length === 2)
 }

--- a/lib/volume-parser.js
+++ b/lib/volume-parser.js
@@ -12,7 +12,7 @@ exports.parseVolume = (fieldTagV) => {
     /(?:^|\s|-)(?:reel|r\.?)\s?(\d*)[-|/]?(\d*)?/gi,
     /(?:^|\s|-)(?:no\.?)\s?(\d*)[-|/]?(\d*)?/gi,
     /jaarg\.?/gi,
-    /\b(\d{1,3})\b/
+    /\b(\d{1,3})\b/g
   ]
 
   let volumes = []

--- a/lib/volume-parser.js
+++ b/lib/volume-parser.js
@@ -11,22 +11,19 @@ exports.parseVolume = (fieldTagV) => {
     /(?:^|\s|-)(?:bd\.?)\s?(\d*)[-|/]?(\d*)?/gi,
     /(?:^|\s|-)(?:reel|r\.?)\s?(\d*)[-|/]?(\d*)?/gi,
     /(?:^|\s|-)(?:no\.?)\s?(\d*)[-|/]?(\d*)?/gi,
-    // FIXME: This is never evaluated:
-    /jaarg\.?/gi //,
-
-    // FIXME: If the "fieldTagV" value is just "21", we should accept that as a vol statement
-    // /\b(\d{1,3})\b/
+    /jaarg\.?/gi,
+    /\b(\d{1,3})\b/
   ]
 
-  let volumes
+  let volumes = []
   // loop through regular expressions
   regExp.forEach((exp) => {
     // we only want to match on one type of regular expression to avoid
     // weirdness with field tag vs that have vol. and no.
-    if (!volumes) {
+    if (!volumes.length) {
       // convert regexp iterator into array so we can get successive matches
       const matches = [...fieldTagV.matchAll(exp)]
-      // returns nested array with ranges [[4,10],[11,15]
+      // returns nested array with ranges, ie [[4,10],[11,15]]
       volumes = extractVols(matches)
     }
   })

--- a/lib/volume-parser.js
+++ b/lib/volume-parser.js
@@ -2,6 +2,7 @@
  * Given a fieldtag v value, returns an array of ranges, each represented as a
  * two element array
  */
+
 exports.parseVolume = (fieldTagV) => {
   const regExp = [
     // Captured values are the numbers found after volume/vol/v, no, bd, and reel/r with or without periods
@@ -17,30 +18,33 @@ exports.parseVolume = (fieldTagV) => {
     // /\b(\d{1,3})\b/
   ]
 
-  let volumesFound = false
   let volumes
   // loop through regular expressions
   regExp.forEach((exp) => {
     // we only want to match on one type of regular expression to avoid
     // weirdness with field tag vs that have vol. and no.
-    if (!volumesFound) {
-      // convert regexp iterator into array so we can get successive matches a
+    if (!volumes) {
+      // convert regexp iterator into array so we can get successive matches
       const matches = [...fieldTagV.matchAll(exp)]
-      volumes = matches.reduce((vols, match) => {
-        // extract the numbers from regex array-like object
-        match = match.slice(1, 3)
-          // Eliminate null valuesconvert from string to int
-          .filter(m => m)
-          // convert from string to int
-          .map(m => parseInt(m, 10))
-        if (match.length) volumesFound = true
-        // [6,7,8] ==> [6,8]
-        if (match.length > 2) match = [match[0], match[match.length - 1]]
-        if (match.length === 1) match = [match[0], match[0]]
-        return [...vols, match]
-      }, [])
+      // returns nested array with ranges [[4,10],[11,15]
+      volumes = extractVols(matches)
     }
   })
   return volumes
     .filter((range) => Array.isArray(range) && range.length === 2)
+}
+
+const extractVols = (matches) => {
+  return matches.reduce((vols, match) => {
+    // extract the numbers from regex array-like object
+    match = match.slice(1, 3)
+      // Eliminate null values
+      .filter(m => m)
+      // convert from string to int
+      .map(m => parseInt(m, 10))
+    // [6,7,8] ==> [6,8]
+    if (match.length > 2) match = [match[0], match[match.length - 1]]
+    if (match.length === 1) match = [match[0], match[0]]
+    return [...vols, match]
+  }, [])
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "avsc": "^4.1.9",
         "aws-sdk": "^2.96.0",
         "bluebird": "^3.7.2",
-        "discovery-store-models": "git+https://github.com/NYPL-discovery/discovery-store-models.git#v1.4.0",
+        "discovery-store-models": "github:NYPL-discovery/discovery-store-models#v1.5.0",
         "highland": "^2.10.0",
         "loglevel": "^1.4.1",
         "mkdirp": "^0.5.1",
@@ -1521,12 +1521,12 @@
       }
     },
     "node_modules/discovery-store-models": {
-      "version": "1.4.0",
-      "resolved": "git+ssh://git@github.com/NYPL-discovery/discovery-store-models.git#db629bc89dd8d8c26cc8e1e1aa11a515fb9f35a6",
-      "integrity": "sha512-QqvhjVbpSXeGrMxKrR0+OKR0jDUOYd9ZZaPtEfaMndmIW49Ts6HQi7IdYbF/UGNBaKbIswqqlUKPLpc8LzdGQw==",
+      "version": "1.5.0",
+      "resolved": "git+ssh://git@github.com/NYPL-discovery/discovery-store-models.git#40acac46a231b9eac185e7670df7eea5480378c6",
       "license": "ISC",
       "dependencies": {
         "@nypl/nypl-core-objects": "^2.0.0",
+        "pg-int8": "^1.0.1",
         "pg-promise": "^7.4.0",
         "winston": "^2.4.0"
       }
@@ -4285,6 +4285,14 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
       "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/pg-minify": {
       "version": "0.5.5",
@@ -7443,11 +7451,11 @@
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
     },
     "discovery-store-models": {
-      "version": "git+ssh://git@github.com/NYPL-discovery/discovery-store-models.git#db629bc89dd8d8c26cc8e1e1aa11a515fb9f35a6",
-      "integrity": "sha512-QqvhjVbpSXeGrMxKrR0+OKR0jDUOYd9ZZaPtEfaMndmIW49Ts6HQi7IdYbF/UGNBaKbIswqqlUKPLpc8LzdGQw==",
-      "from": "discovery-store-models@git+https://github.com/NYPL-discovery/discovery-store-models.git#v1.4.0",
+      "version": "git+ssh://git@github.com/NYPL-discovery/discovery-store-models.git#40acac46a231b9eac185e7670df7eea5480378c6",
+      "from": "discovery-store-models@git+https://github.com/NYPL-discovery/discovery-store-models.git#v1.5.0",
       "requires": {
         "@nypl/nypl-core-objects": "^2.0.0",
+        "pg-int8": "^1.0.1",
         "pg-promise": "^7.4.0",
         "winston": "^2.4.0"
       }
@@ -9591,6 +9599,11 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
       "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
     "pg-minify": {
       "version": "0.5.5",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "avsc": "^4.1.9",
     "aws-sdk": "^2.96.0",
     "bluebird": "^3.7.2",
-    "discovery-store-models": "git+https://github.com/NYPL-discovery/discovery-store-models.git#v1.4.0",
+    "discovery-store-models": "github:NYPL-discovery/discovery-store-models#v1.5.0",
     "highland": "^2.10.0",
     "loglevel": "^1.4.1",
     "mkdirp": "^0.5.1",

--- a/scripts/print-statements-for-resource.js
+++ b/scripts/print-statements-for-resource.js
@@ -14,7 +14,10 @@ const BibSierraRecord = require('../lib/models/bib-sierra-record')
 const BibsUpdater = require('../lib/bibs-updater')
 const ItemSierraRecord = require('../lib/models/item-sierra-record')
 const ItemsUpdater = require('../lib/items-updater')
+const HoldingsUpdater = require('../lib/holdings-updater')
+const HoldingSierraRecord = require('../lib/models/holding-sierra-record')
 const NyplSourceMapper = require('discovery-store-models/lib/nypl-source-mapper')
+const utils = require('../lib/utils')
 
 var argv = require('optimist')
   .usage('Usage: $0 [--offset=num] [--limit=num]')
@@ -48,11 +51,23 @@ if (argv.uri) {
       return itemsUpdater.itemByApi(nyplSource, id)
         .then(ItemSierraRecord.from)
         .then(itemsUpdater.extractStatements.bind(itemsUpdater))
+    },
+    holding: () => {
+      const holdingsUpdater = new HoldingsUpdater()
+      return holdingsUpdater.holdingByApi(id)
+        .then(HoldingSierraRecord.from)
+        .then(holdingsUpdater.extractStatements.bind(holdingsUpdater))
     }
   }[type]
 
   statements()
     .then((statements) => {
-      console.log('Statements: ', statements)
+      const subjects = utils.groupBy(statements, 'subject_id')
+      subjects.forEach((group) => {
+        const subjectId = group[0].subject_id
+        console.log('======================')
+        console.log(`${subjectId}:`)
+        console.log(group)
+      })
     })
 }

--- a/test/data/holding-1032862.json
+++ b/test/data/holding-1032862.json
@@ -1,0 +1,316 @@
+{
+  "id": 1032862,
+  "bibIds": [
+    12959619
+  ],
+  "bibIdLinks": [
+    "https://ilsstaff.nypl.org/iii/sierra-api/v6/bibs/12959619"
+  ],
+  "itemIds": [],
+  "itemIdLinks": [],
+  "inheritLocation": false,
+  "allocationRule": null,
+  "accountingUnit": 1,
+  "labelCode": "n",
+  "serialCode1": "a",
+  "serialCode2": "-",
+  "serialCode3": "-",
+  "serialCode4": "-",
+  "claimOnDate": null,
+  "receivingLocationCode": "17",
+  "vendorCode": "aahgs",
+  "updateCount": "z",
+  "pieceCount": 0,
+  "eCheckInCode": " ",
+  "mediaTypeCode": " ",
+  "updatedDate": "2021-07-08",
+  "createdDate": "2009-06-23",
+  "deletedDate": null,
+  "deleted": false,
+  "suppressed": false,
+  "fixedFields": {
+    "35": {
+      "label": "Label Type",
+      "value": "n",
+      "display": null
+    },
+    "36": {
+      "label": "Serial Code 1",
+      "value": "a",
+      "display": null
+    },
+    "37": {
+      "label": "Serial Code 2",
+      "value": "-",
+      "display": null
+    },
+    "38": {
+      "label": "Copies",
+      "value": "1",
+      "display": null
+    },
+    "40": {
+      "label": "Location",
+      "value": "scf  ",
+      "display": null
+    },
+    "41": {
+      "label": "Recv Location",
+      "value": "17 ",
+      "display": null
+    },
+    "42": {
+      "label": "Vendor",
+      "value": "aahgs",
+      "display": null
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "c",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "1032862",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": "2009-06-23T07:20:00Z",
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2021-07-08T21:09:41Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": "24",
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "1",
+      "display": null
+    },
+    "98": {
+      "label": "PDATE",
+      "value": "2012-04-06T16:53:00Z",
+      "display": null
+    },
+    "118": {
+      "label": "Serial Code 3",
+      "value": "-",
+      "display": null
+    },
+    "119": {
+      "label": "Serial Code 4",
+      "value": "-",
+      "display": null
+    },
+    "120": {
+      "label": "Update Count",
+      "value": "z",
+      "display": null
+    },
+    "121": {
+      "label": "Piece Count",
+      "value": "0",
+      "display": null
+    },
+    "137": {
+      "label": "E-Checkin",
+      "value": " ",
+      "display": null
+    },
+    "159": {
+      "label": "Media Type",
+      "value": " ",
+      "display": null
+    },
+    "266": {
+      "label": "Inherit Location",
+      "value": "false",
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "ind1": null,
+      "ind2": null,
+      "content": "00000ny   22000003n 4500",
+      "marcTag": null,
+      "fieldTag": "_",
+      "subfields": null
+    },
+    {
+      "ind1": "8",
+      "ind2": " ",
+      "content": null,
+      "marcTag": "852",
+      "fieldTag": "c",
+      "subfields": [
+        {
+          "tag": "h",
+          "content": "Sc Ser.-M .N489"
+        }
+      ]
+    },
+    {
+      "ind1": null,
+      "ind2": null,
+      "content": ".c1998006",
+      "marcTag": null,
+      "fieldTag": "d",
+      "subfields": null
+    },
+    {
+      "ind1": null,
+      "ind2": null,
+      "content": "Jan 1997-2011. INCOMPLETE",
+      "marcTag": null,
+      "fieldTag": "h",
+      "subfields": null
+    },
+    {
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "marcTag": "843",
+      "fieldTag": "i",
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "PRINT"
+        }
+      ]
+    },
+    {
+      "ind1": null,
+      "ind2": null,
+      "content": "Due on membership, order# o10430635.  Thank you.",
+      "marcTag": null,
+      "fieldTag": "v",
+      "subfields": null
+    }
+  ],
+  "holdings": [
+    {
+      "index": false,
+      "negation": false,
+      "incomplete": false,
+      "holding_ranges": [],
+      "holding_string": "Jan 1997-2011. INCOMPLETE"
+    },
+    {
+      "index": false,
+      "negation": false,
+      "incomplete": false,
+      "holding_ranges": [],
+      "holding_string": ""
+    }
+  ],
+  "location": {
+    "code": "scf",
+    "label": "Schomburg Center - Research & Reference"
+  },
+  "checkInCards": [
+    {
+      "url": null,
+      "note": null,
+      "box_id": 420595,
+      "status": {
+        "code": "A",
+        "label": "Arrived"
+      },
+      "end_date": null,
+      "box_count": 1,
+      "copy_count": null,
+      "holding_id": 1032862,
+      "staff_note": null,
+      "start_date": "Jan. 2012",
+      "suppressed": "f",
+      "claim_count": 0,
+      "enumeration": {
+        "levels": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "enumeration": null
+      },
+      "trans_end_date": null,
+      "trans_start_date": "Feb. 13, 2012"
+    },
+    {
+      "url": null,
+      "note": null,
+      "box_id": 420601,
+      "status": {
+        "code": "A",
+        "label": "Arrived"
+      },
+      "end_date": null,
+      "box_count": 2,
+      "copy_count": null,
+      "holding_id": 1032862,
+      "staff_note": null,
+      "start_date": "Mar. 2012",
+      "suppressed": "f",
+      "claim_count": 0,
+      "enumeration": {
+        "levels": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "enumeration": null
+      },
+      "trans_end_date": null,
+      "trans_start_date": "Apr. 6, 2012"
+    },
+    {
+      "url": null,
+      "note": null,
+      "box_id": 420607,
+      "status": {
+        "code": "E",
+        "label": "Expected"
+      },
+      "end_date": null,
+      "box_count": 3,
+      "copy_count": null,
+      "holding_id": 1032862,
+      "staff_note": null,
+      "start_date": "May. 2012",
+      "suppressed": null,
+      "claim_count": 0,
+      "enumeration": {
+        "levels": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "enumeration": null
+      },
+      "trans_end_date": null,
+      "trans_start_date": "Jun. 4, 2012"
+    }
+  ]
+}

--- a/test/data/holding-with-volume-range.json
+++ b/test/data/holding-with-volume-range.json
@@ -1,0 +1,385 @@
+{
+  "id": 1089484,
+  "bibIds": [
+    16543663
+  ],
+  "bibIdLinks": [
+    "https://ilsstaff.nypl.org/iii/sierra-api/v6/bibs/16543663"
+  ],
+  "itemIds": [],
+  "itemIdLinks": [],
+  "inheritLocation": false,
+  "allocationRule": null,
+  "accountingUnit": 1,
+  "labelCode": "a",
+  "serialCode1": "a",
+  "serialCode2": "-",
+  "serialCode3": "-",
+  "serialCode4": "-",
+  "claimOnDate": "2019-04-01T04:00:00Z",
+  "receivingLocationCode": "3",
+  "vendorCode": "ybp",
+  "updateCount": "z",
+  "pieceCount": 0,
+  "eCheckInCode": " ",
+  "mediaTypeCode": " ",
+  "updatedDate": "2020-09-14",
+  "createdDate": "2009-06-23",
+  "deletedDate": null,
+  "deleted": false,
+  "suppressed": false,
+  "fixedFields": {
+    "35": {
+      "label": "Label Type",
+      "value": "a",
+      "display": null
+    },
+    "36": {
+      "label": "Serial Code 1",
+      "value": "a",
+      "display": null
+    },
+    "37": {
+      "label": "Serial Code 2",
+      "value": "-",
+      "display": null
+    },
+    "38": {
+      "label": "Copies",
+      "value": "1",
+      "display": null
+    },
+    "39": {
+      "label": "Claim On",
+      "value": "2019-04-01",
+      "display": null
+    },
+    "40": {
+      "label": "Location",
+      "value": "slrb1",
+      "display": null
+    },
+    "41": {
+      "label": "Recv Location",
+      "value": "3  ",
+      "display": null
+    },
+    "42": {
+      "label": "Vendor",
+      "value": "ybp  ",
+      "display": null
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "c",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "1089484",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": "2009-06-23T16:24:00Z",
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2020-09-14T18:44:12Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": "22",
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "1",
+      "display": null
+    },
+    "98": {
+      "label": "PDATE",
+      "value": "2018-10-01T15:49:08Z",
+      "display": null
+    },
+    "118": {
+      "label": "Serial Code 3",
+      "value": "-",
+      "display": null
+    },
+    "119": {
+      "label": "Serial Code 4",
+      "value": "-",
+      "display": null
+    },
+    "120": {
+      "label": "Update Count",
+      "value": "z",
+      "display": null
+    },
+    "121": {
+      "label": "Piece Count",
+      "value": "0",
+      "display": null
+    },
+    "137": {
+      "label": "E-Checkin",
+      "value": " ",
+      "display": null
+    },
+    "159": {
+      "label": "Media Type",
+      "value": " ",
+      "display": null
+    },
+    "266": {
+      "label": "Inherit Location",
+      "value": "false",
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "ind1": null,
+      "ind2": null,
+      "content": "00000ny   22000003n 4500",
+      "marcTag": null,
+      "fieldTag": "_",
+      "subfields": null
+    },
+    {
+      "ind1": "0",
+      "ind2": "1",
+      "content": null,
+      "marcTag": "852",
+      "fieldTag": "c",
+      "subfields": [
+        {
+          "tag": "k",
+          "content": "*R-SIBL"
+        },
+        {
+          "tag": "h",
+          "content": "NK9509"
+        },
+        {
+          "tag": "i",
+          "content": ".T722"
+        },
+        {
+          "tag": "z",
+          "content": "Latest ed."
+        }
+      ]
+    },
+    {
+      "ind1": "8",
+      "ind2": " ",
+      "content": null,
+      "marcTag": "852",
+      "fieldTag": "c",
+      "subfields": [
+        {
+          "tag": "h",
+          "content": "JBM 07-158"
+        },
+        {
+          "tag": "z",
+          "content": "Bound vols."
+        }
+      ]
+    },
+    {
+      "ind1": null,
+      "ind2": null,
+      "content": ".c2407772",
+      "marcTag": null,
+      "fieldTag": "d",
+      "subfields": null
+    },
+    {
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "marcTag": "863",
+      "fieldTag": "h",
+      "subfields": [
+        {
+          "tag": "8",
+          "content": "1.1"
+        },
+        {
+          "tag": "a",
+          "content": "20"
+        },
+        {
+          "tag": "i",
+          "content": "2015"
+        },
+        {
+          "tag": "j",
+          "content": ""
+        },
+        {
+          "tag": "k",
+          "content": ""
+        }
+      ]
+    },
+    {
+      "ind1": null,
+      "ind2": null,
+      "content": "[Bound vols.-SIBL Delivery Desk] ed. 14 (2007)-ed. 19 (2013),",
+      "marcTag": null,
+      "fieldTag": "h",
+      "subfields": null
+    },
+    {
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "marcTag": "843",
+      "fieldTag": "i",
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "PRINT     "
+        }
+      ]
+    },
+    {
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "marcTag": "930",
+      "fieldTag": "o",
+      "subfields": [
+        {
+          "tag": "8",
+          "content": "04-30-07"
+        },
+        {
+          "tag": "9",
+          "content": "11-08-08"
+        },
+        {
+          "tag": "j",
+          "content": "10-29-10"
+        },
+        {
+          "tag": "m",
+          "content": "b5"
+        }
+      ]
+    },
+    {
+      "ind1": null,
+      "ind2": null,
+      "content": "#26",
+      "marcTag": null,
+      "fieldTag": "w",
+      "subfields": null
+    },
+    {
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "marcTag": "853",
+      "fieldTag": "y",
+      "subfields": [
+        {
+          "tag": "8",
+          "content": "1"
+        },
+        {
+          "tag": "a",
+          "content": "ed. "
+        },
+        {
+          "tag": "i",
+          "content": "(year)"
+        },
+        {
+          "tag": "j",
+          "content": "(month)"
+        },
+        {
+          "tag": "k",
+          "content": "(day)"
+        }
+      ]
+    },
+    {
+      "ind1": null,
+      "ind2": null,
+      "content": "***CHECKIN & BIND***",
+      "marcTag": null,
+      "fieldTag": "z",
+      "subfields": null
+    },
+    {
+      "ind1": null,
+      "ind2": null,
+      "content": "Is it now biennial? /BH/5/4/15.",
+      "marcTag": null,
+      "fieldTag": "z",
+      "subfields": null
+    }
+  ],
+  "holdings": [
+    {
+      "index": false,
+      "negation": false,
+      "incomplete": false,
+      "holding_ranges": [],
+      "holding_string": "[Bound vols.-SIBL Delivery Desk] ed. 14 (2007)-ed. 19 (2013),"
+    },
+    {
+      "index": false,
+      "negation": false,
+      "incomplete": false,
+      "holding_ranges": [],
+      "holding_string": "ed.  20 (2015)"
+    }
+  ],
+  "location": {
+    "code": "slrb1",
+    "label": "Science, Industry and Business Library (SIBL) - Reference"
+  },
+  "checkInCards": [
+    {
+      "url": null,
+      "note": null,
+      "box_id": 834530,
+      "status": {
+        "code": "E",
+        "label": "Expected"
+      },
+      "end_date": null,
+      "box_count": 2,
+      "copy_count": null,
+      "holding_id": 1089484,
+      "staff_note": "PL asked to investigate/BH/10/1/18",
+      "start_date": "--",
+      "suppressed": "f",
+      "claim_count": 1,
+      "enumeration": {
+        "levels": [
+          "21",
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "enumeration": "v21-26"
+      },
+      "trans_end_date": null,
+      "trans_start_date": "2018-10-1"
+    }
+  ]
+}

--- a/test/data/holding-with-volume-range.json
+++ b/test/data/holding-with-volume-range.json
@@ -380,6 +380,39 @@
       },
       "trans_end_date": null,
       "trans_start_date": "2018-10-1"
+    },
+    {
+      "url": null,
+      "note": null,
+      "box_id": 834530,
+      "status": {
+        "code": "E",
+        "label": "Expected"
+      },
+      "end_date": null,
+      "box_count": 2,
+      "copy_count": null,
+      "holding_id": 1089484,
+      "staff_note": "PL asked to investigate/BH/10/1/18",
+      "start_date": "--",
+      "suppressed": "f",
+      "claim_count": 1,
+      "enumeration": {
+        "levels": [
+          "21",
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "enumeration": "21"
+      },
+      "trans_end_date": null,
+      "trans_start_date": "2018-10-1"
     }
+
   ]
 }

--- a/test/holding-marc-test.js
+++ b/test/holding-marc-test.js
@@ -137,7 +137,7 @@ describe('Holding Marc Mapping', () => {
         })
     })
 
-    it.only('should create item statement for volume range', () => {
+    it('should create item statement for volume range', () => {
       const holding = HoldingSierraRecord.from(require('./data/holding-with-volume-range.json'))
       return holdingSerializer.fromMarcJson(holding)
         .then((statements) => {
@@ -149,6 +149,8 @@ describe('Holding Marc Mapping', () => {
           }, {})
           expect(statementsBySubjectId['i-h1089484-0'].filter((s) => s.predicate === 'nypl:volumeRange')[0].object_literal)
             .to.deep.equal([21, 26])
+          expect(statementsBySubjectId['i-h1089484-1'].filter((s) => s.predicate === 'nypl:volumeRange')[0].object_literal)
+            .to.deep.equal([21, 21])
         })
     })
     it('should create item statements with parsed date ranges for each checkin card box', () => {
@@ -166,7 +168,6 @@ describe('Holding Marc Mapping', () => {
             .to.deep.equal(['2012-01-01', '2012-01-01'])
           expect(statementsBySubjectId['i-h1032862-0'].filter((s) => s.predicate === 'bf:enumerationAndChronology')[0].object_literal)
             .to.equal('Jan. 2012')
-
           expect(statementsBySubjectId['i-h1032862-1'].filter((s) => s.predicate === 'nypl:dateRange')[0].object_literal)
             .to.deep.equal(['2012-03-01', '2012-03-01'])
           expect(statementsBySubjectId['i-h1032862-1'].filter((s) => s.predicate === 'bf:enumerationAndChronology')[0].object_literal)

--- a/test/holding-marc-test.js
+++ b/test/holding-marc-test.js
@@ -100,12 +100,13 @@ describe('Holding Marc Mapping', () => {
           assert.strictEqual(checkInBox2.literal('bf:part'), 2)
         })
     })
+
     it('should create item statements for each checkin card box', () => {
       const holding = HoldingSierraRecord.from(require('./data/holding-1089484.json'))
       return holdingSerializer.fromMarcJson(holding)
-        .then((statements) => new Holding(statements))
-        .then((item) => {
-
+        .then((statements) => {
+          assert(statements.some((statement) => statement.subject_id.includes('-0')))
+          assert(statements.some((statement) => statement.subject_id.includes('-1')))
         })
     })
 

--- a/test/holding-marc-test.js
+++ b/test/holding-marc-test.js
@@ -147,9 +147,8 @@ describe('Holding Marc Mapping', () => {
             h[s.subject_id].push(s)
             return h
           }, {})
-          console.log(statementsBySubjectId['i-h1089484-0'].filter((s) => s.predicate === 'nypl:VolumeRange'))
-          expect(statementsBySubjectId['i-h1089484-0'].filter((s) => s.predicate === 'nypl:VolumeRange')[0].object_literal)
-            .to.deep.equal(['21,26'])
+          expect(statementsBySubjectId['i-h1089484-0'].filter((s) => s.predicate === 'nypl:volumeRange')[0].object_literal)
+            .to.deep.equal([21, 26])
         })
     })
     it('should create item statements with parsed date ranges for each checkin card box', () => {

--- a/test/holding-marc-test.js
+++ b/test/holding-marc-test.js
@@ -110,7 +110,6 @@ describe('Holding Marc Mapping', () => {
           assert(statements.some((statement) => statement.subject_id.includes('-0')))
           assert(statements.some((statement) => statement.subject_id.includes('-1')))
           // assert that all statements were added
-          assert(statements.some((statement) => statement.predicate.includes('volumeRange')))
           assert(statements.some((statement) => statement.predicate.includes('volumeRaw')))
 
           // Assert that this fixture has no parsable dates because it has
@@ -138,6 +137,21 @@ describe('Holding Marc Mapping', () => {
         })
     })
 
+    it.only('should create item statement for volume range', () => {
+      const holding = HoldingSierraRecord.from(require('./data/holding-with-volume-range.json'))
+      return holdingSerializer.fromMarcJson(holding)
+        .then((statements) => {
+          // Group by subject (i.e. item) id:
+          const statementsBySubjectId = statements.reduce((h, s) => {
+            if (!h[s.subject_id]) h[s.subject_id] = []
+            h[s.subject_id].push(s)
+            return h
+          }, {})
+          console.log(statementsBySubjectId['i-h1089484-0'].filter((s) => s.predicate === 'nypl:VolumeRange'))
+          expect(statementsBySubjectId['i-h1089484-0'].filter((s) => s.predicate === 'nypl:VolumeRange')[0].object_literal)
+            .to.deep.equal(['21,26'])
+        })
+    })
     it('should create item statements with parsed date ranges for each checkin card box', () => {
       const holding = HoldingSierraRecord.from(require('./data/holding-1032862.json'))
       return holdingSerializer.fromMarcJson(holding)

--- a/test/holding-marc-test.js
+++ b/test/holding-marc-test.js
@@ -105,8 +105,18 @@ describe('Holding Marc Mapping', () => {
       const holding = HoldingSierraRecord.from(require('./data/holding-1089484.json'))
       return holdingSerializer.fromMarcJson(holding)
         .then((statements) => {
+          // assert that both checkin cards got processed
           assert(statements.some((statement) => statement.subject_id.includes('-0')))
           assert(statements.some((statement) => statement.subject_id.includes('-1')))
+          // assert that all statements were added
+          assert(statements.some((statement) => statement.predicate.includes('volumeRange')))
+          assert(statements.some((statement) => statement.predicate.includes('volumeRaw')))
+          assert(statements.some((statement) => statement.predicate.includes('dateRange')))
+          assert(statements.some((statement) => statement.predicate.includes('status')))
+          assert(statements.some((statement) => statement.predicate.includes('shelfMark')))
+          assert(statements.some((statement) => statement.predicate.includes('format')))
+          assert(statements.some((statement) => statement.predicate.includes('accessMessage')))
+          assert(statements.some((statement) => statement.predicate.includes('enumerationAndChronology')))
         })
     })
 

--- a/test/holding-marc-test.js
+++ b/test/holding-marc-test.js
@@ -1,5 +1,6 @@
 /* global describe it */
 
+const expect = require('chai').expect
 const assert = require('assert')
 const holdingSerializer = require('./../lib/serializers/holding')
 const HoldingSierraRecord = require('./../lib/models/holding-sierra-record')
@@ -111,7 +112,11 @@ describe('Holding Marc Mapping', () => {
           // assert that all statements were added
           assert(statements.some((statement) => statement.predicate.includes('volumeRange')))
           assert(statements.some((statement) => statement.predicate.includes('volumeRaw')))
-          assert(statements.some((statement) => statement.predicate.includes('dateRange')))
+
+          // Assert that this fixture has no parsable dates because it has
+          // start_date '--' and end_date null
+          assert(!statements.some((statement) => statement.predicate.includes('dateRange')))
+
           assert(statements.some((statement) => statement.predicate.includes('status')))
           assert(statements.some((statement) => statement.predicate.includes('shelfMark')))
           assert(statements.some((statement) => statement.predicate.includes('format')))
@@ -130,6 +135,34 @@ describe('Holding Marc Mapping', () => {
           assert.strictEqual(holding.objectId('nypl:bnum'), 'urn:bnum:b11929657')
           assert.strictEqual(holding.literals('bf:note')[0], 'Checkin **EDITION SPECIALE** here.')
           assert.strictEqual(holding.literals('bf:note')[1], 'IRREGULAR')
+        })
+    })
+
+    it('should create item statements with parsed date ranges for each checkin card box', () => {
+      const holding = HoldingSierraRecord.from(require('./data/holding-1032862.json'))
+      return holdingSerializer.fromMarcJson(holding)
+        .then((statements) => {
+          // Group by subject (i.e. item) id:
+          const statementsBySubjectId = statements.reduce((h, s) => {
+            if (!h[s.subject_id]) h[s.subject_id] = []
+            h[s.subject_id].push(s)
+            return h
+          }, {})
+
+          expect(statementsBySubjectId['i-h1032862-0'].filter((s) => s.predicate === 'nypl:dateRange')[0].object_literal)
+            .to.deep.equal(['2012-01-01', '2012-01-01'])
+          expect(statementsBySubjectId['i-h1032862-0'].filter((s) => s.predicate === 'bf:enumerationAndChronology')[0].object_literal)
+            .to.equal('Jan. 2012')
+
+          expect(statementsBySubjectId['i-h1032862-1'].filter((s) => s.predicate === 'nypl:dateRange')[0].object_literal)
+            .to.deep.equal(['2012-03-01', '2012-03-01'])
+          expect(statementsBySubjectId['i-h1032862-1'].filter((s) => s.predicate === 'bf:enumerationAndChronology')[0].object_literal)
+            .to.equal('Mar. 2012')
+
+          expect(statementsBySubjectId['i-h1032862-2'].filter((s) => s.predicate === 'nypl:dateRange')[0].object_literal)
+            .to.deep.equal(['2012-05-01', '2012-05-01'])
+          expect(statementsBySubjectId['i-h1032862-2'].filter((s) => s.predicate === 'bf:enumerationAndChronology')[0].object_literal)
+            .to.equal('May. 2012')
         })
     })
   })

--- a/test/holding-marc-test.js
+++ b/test/holding-marc-test.js
@@ -100,6 +100,14 @@ describe('Holding Marc Mapping', () => {
           assert.strictEqual(checkInBox2.literal('bf:part'), 2)
         })
     })
+    it('should create item statements for each checkin card box', () => {
+      const holding = HoldingSierraRecord.from(require('./data/holding-1089484.json'))
+      return holdingSerializer.fromMarcJson(holding)
+        .then((statements) => new Holding(statements))
+        .then((item) => {
+
+        })
+    })
 
     it('should create multiple note statements', () => {
       const holding = HoldingSierraRecord.from(require('./data/holding-1066022.json'))

--- a/test/volume-parse-test.js
+++ b/test/volume-parse-test.js
@@ -2,7 +2,7 @@
 const expect = require('chai').expect
 const { parseVolume } = require('../lib/volume-parser')
 
-describe('volume parsing', () => {
+describe.only('volume parsing', () => {
   it('v. 36-37 (Nov. 1965-Oct. 1967)', () => {
     expect(parseVolume('v. 36-37 (Nov. 1965-Oct. 1967)')).to.deep.equal([[36, 37]])
   })

--- a/test/volume-parse-test.js
+++ b/test/volume-parse-test.js
@@ -21,4 +21,10 @@ describe.only('volume parsing', () => {
   it('v. 6-7 no. 2, 5-v. 8-10 no. 1 (Oct. 1961-Sept./Oct. 1962, May-June/July 1963)', () => {
     expect(parseVolume('v. 6-7 no. 2, 5-v. 8-10 no. 1 (Oct. 1961-Sept./Oct. 1962, May-June/July 1963)')).to.deep.equal([[6, 7], [8, 10]])
   })
+  it('returns empty array for strings without obvious volume information', () => {
+    expect(parseVolume('')).to.deep.equal([])
+    expect(parseVolume('vol')).to.deep.equal([])
+    expect(parseVolume('no. a')).to.deep.equal([])
+    expect(parseVolume('May-June/July 1963')).to.deep.equal([])
+  })
 })

--- a/test/volume-parse-test.js
+++ b/test/volume-parse-test.js
@@ -2,7 +2,7 @@
 const expect = require('chai').expect
 const { parseVolume } = require('../lib/volume-parser')
 
-describe.only('volume parsing', () => {
+describe('volume parsing', () => {
   it('v. 36-37 (Nov. 1965-Oct. 1967)', () => {
     expect(parseVolume('v. 36-37 (Nov. 1965-Oct. 1967)')).to.deep.equal([[36, 37]])
   })


### PR DESCRIPTION
Adds functionality to existing iteration over checkinCards to create item statements per checkin card box on a holding

- add new holding status mapping object based on [this sheet](https://docs.google.com/spreadsheets/d/1Bbtm_EHn86qzNICVhXGv_78nP1pshkLlik0EuJAES3g/edit#gid=0)https://docs.go
- incorporates volume parsing per temporary item