### PR TITLE
Fix: holding serializer extracts checkin card location

### DIFF
--- a/lib/serializers/holding.js
+++ b/lib/serializers/holding.js
@@ -66,13 +66,15 @@ const fromMarcJson = (object) => {
 
     // Location(s)
     let location
+    let holdingLocationEntity
     if (object.location) location = { value: object.location.code, path: 'location' }
 
     // Valid location?
     if (location && sierraLocationMapping[location.value]) {
       const holdingLocationId = `loc:${location.value}`
       const holdingLocationLabel = sierraLocationMapping[location.value].label
-      builder.add(fieldMapper.predicateFor('Location'), { id: holdingLocationId, label: holdingLocationLabel }, 0, { path: location.path })
+      holdingLocationEntity = { id: holdingLocationId, label: holdingLocationLabel }
+      builder.add(fieldMapper.predicateFor('Location'), holdingLocationEntity, 0, { path: location.path })
     } else if (location && location.value) {
       log.warn('Location id not recognized: ' + location.value)
     }
@@ -182,6 +184,10 @@ const fromMarcJson = (object) => {
         }
       }
       checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Availability'), holdingStatusMapping[box.status.code], index)
+
+      if (holdingLocationEntity) {
+        checkInCardItemBuilder.add(itemFieldMapper.predicateFor('Holding location'), holdingLocationEntity)
+      }
 
       return checkInCardItemBuilder.statements
     })

--- a/test/holding-marc-test.js
+++ b/test/holding-marc-test.js
@@ -151,6 +151,8 @@ describe('Holding Marc Mapping', () => {
             .to.deep.equal([21, 26])
           expect(statementsBySubjectId['i-h1089484-1'].filter((s) => s.predicate === 'nypl:volumeRange')[0].object_literal)
             .to.deep.equal([21, 21])
+          expect(statementsBySubjectId['i-h1089484-1'].filter((s) => s.predicate === 'nypl:holdingLocation')[0].object_id)
+            .to.deep.equal('loc:slrb1')
         })
     })
     it('should create item statements with parsed date ranges for each checkin card box', () => {
@@ -177,6 +179,8 @@ describe('Holding Marc Mapping', () => {
             .to.deep.equal(['2012-05-01', '2012-05-01'])
           expect(statementsBySubjectId['i-h1032862-2'].filter((s) => s.predicate === 'bf:enumerationAndChronology')[0].object_literal)
             .to.equal('May. 2012')
+          expect(statementsBySubjectId['i-h1032862-2'].filter((s) => s.predicate === 'nypl:holdingLocation')[0].object_id)
+            .to.equal('loc:scf')
         })
     })
   })


### PR DESCRIPTION
Fix to holding serializer to ensure that items generated from checkin cards have holdingLocation statements. This was somehow left out of the ticket when it was created from the TAD.