### PR TITLE
fix label typo

### DIFF
--- a/lib/holding-status-mapping.js
+++ b/lib/holding-status-mapping.js
@@ -1,4 +1,4 @@
-const notAvailable = { id: 'status:na', label: 'Not Available (ReCAP' }
+const notAvailable = { id: 'status:na', label: 'Not Available (ReCAP)' }
 const available = { id: 'status:a', label: 'Available' }
 const bindery = { id: 'status:i', label: 'At bindery' }
 


### PR DESCRIPTION
I noticed a missing parenthesis in the label. However, I'm also confused as to why anything that is unavailable will say (ReCAP). It sounded like Sean was saying there should really only be available/unavailable visible to patrons on the frontend, so I'm wondering about these labels... Probably a discussion for the new year. 