### PR TITLE
Restrict parsed volumes to ES integer range

### DIFF
--- a/lib/volume-parser.js
+++ b/lib/volume-parser.js
@@ -45,6 +45,9 @@ const extractVols = (matches) => {
       .filter(m => m)
       // convert from string to int
       .map(m => parseInt(m, 10))
+      // Ensure volume is within ES bounds for `int`:
+      .filter((v) => Math.abs(v) < Math.pow(2, 31))
+
     // [6,7,8] ==> [6,8]
     if (match.length > 2) match = [match[0], match[match.length - 1]]
     if (match.length === 1) match = [match[0], match[0]]

--- a/test/volume-parse-test.js
+++ b/test/volume-parse-test.js
@@ -34,4 +34,19 @@ describe('volume parsing', () => {
   it('jaarg. 24 (Jan.-June 1967)', () => {
     expect(parseVolume('jaarg. 24 (Jan.-June 1967)')).to.deep.equal([[24, 24]])
   })
+  it('rejects volumes beyond the range of ints', () => {
+    // This is a volume value just within the accepted int range:
+    const maxInt = Math.pow(2, 31) - 1
+
+    expect(parseVolume(`volume ${maxInt}`)).to.deep.equal([[maxInt, maxInt]])
+
+    // This is a volume value just outside accepted int range:
+    expect(parseVolume(`volume ${maxInt + 1}`)).to.deep.equal([])
+
+    // This is a volume value outside accepted int range:
+    expect(parseVolume('volume 7600010780000')).to.deep.equal([])
+
+    // Should reject only the invalid int:
+    expect(parseVolume('volume 1 - 7600010780000')).to.deep.equal([[1, 1]])
+  })
 })


### PR DESCRIPTION
To address a production indexing issue where a fieldtag v with "no. 7600010780000:26-27" is being interpreted as vol 7600010780000, which is beyond the range of an ES `int` datatype (2^31 - 1). We should just reject parsed volumes that exceed the int range because they're probably not really a "volume" anyway