### PR TITLE
Scc 3400/date parse bug

### DIFF
--- a/lib/date-parse/index.js
+++ b/lib/date-parse/index.js
@@ -67,10 +67,6 @@ const preparse = function (dates) {
     })
     return date
   })
-    // After applying "preparsing" corrections to the data, remove anything
-    // that doesn't have at least a four digit year (minimum for a parsable
-    // date)
-    .filter(_has4DigitYear)
 }
 
 /**
@@ -86,6 +82,9 @@ const _has4DigitYear = (d) => /\b\d{4}\b/.test(d)
 
 const parseDatesAndCache = async function (bibs) {
   const dates = extractFieldtagvs(bibs)
+    // remove anything that doesn't have at least a four digit year
+    // (minimum for a parsable date)
+    .filter(_has4DigitYear)
   try {
     const ranges = await _parseDates(dates)
     dateCache = dates.reduce((cache, date, i) => {

--- a/lib/date-parse/preparsingObjects.js
+++ b/lib/date-parse/preparsingObjects.js
@@ -19,7 +19,11 @@ const parens = {
   matchExpression: /\((.+)\)/,
   transform: function (range) {
     const match = range.match(this.matchExpression)
-    return match[1]
+    if (match[1] === 'second copy') {
+      return range.replace('(second copy)', '')
+    } else {
+      return match[1]
+    }
   },
   exampleString: 'v. 5 (August 1990)'
 }

--- a/lib/date-parse/preparsingObjects.js
+++ b/lib/date-parse/preparsingObjects.js
@@ -16,16 +16,19 @@ const returnOneYear = {
 
 // Extract values from inside parentheses; v. 5 (August 1990)
 const parens = {
-  matchExpression: /\((.+)\)/,
+  matchExpression: /\((.+\b\d{4})\)/,
   transform: function (range) {
     const match = range.match(this.matchExpression)
-    if (match[1] === 'second copy') {
-      return range.replace('(second copy)', '')
-    } else {
-      return match[1]
-    }
+    return match[1]
   },
   exampleString: 'v. 5 (August 1990)'
+}
+
+const removeSecondCopy = {
+  matchExpression: /\(second copy\)/,
+  transform: function (range) {
+    return range.replace('(second copy)', '')
+  }
 }
 
 // 1992:spring
@@ -102,6 +105,6 @@ const yearRangeWithSlash = {
 }
 
 module.exports = {
-  preparsingObjects: [parens, colon, twoYearRangeMulti, yearRangeWithSlash, soloRangeSlash, shortYearBug, monthRangeWithSlash],
+  preparsingObjects: [parens, colon, twoYearRangeMulti, yearRangeWithSlash, soloRangeSlash, shortYearBug, monthRangeWithSlash, removeSecondCopy],
   returnOneYear
 }

--- a/package.json
+++ b/package.json
@@ -46,5 +46,5 @@
   "name": "pcdm-store-updater",
   "preferGlobal": false,
   "private": false,
-  "version": "1.8.1"
+  "version": "1.8.2"
 }

--- a/test/date-parse-test.js
+++ b/test/date-parse-test.js
@@ -24,6 +24,11 @@ describe('dateParser Lambda', () => {
   })
 
   describe('correcly parses a variety of fieldtagvs', () => {
+    it('August 2008 (second copy)', async () => {
+      const fieldtagv = 'August 2008 (second copy)'
+      const [parsed] = await _parseDates(fieldtagv)
+      expect(parsed).to.deep.equal([['2008-08', '2008-08']])
+    })
     it('v. 36-37 (Nov. 1965-Oct. 1967) @local-only', async () => {
       const fieldtagv = 'v. 36-37 (Nov. 1965-Oct. 1967)'
       const [parsed] = await _parseDates(fieldtagv)

--- a/test/date-parse-test.js
+++ b/test/date-parse-test.js
@@ -11,6 +11,7 @@ describe('dateParser Lambda', () => {
       expect(checkCache('v. 36-37 (Nov. 1965-Oct. 1967)')).to.deep.equal([['1965-11', '1967-10']])
       expect(checkCache('v. 6-7 no. 2, 5-v. 8 no. 1 (Oct. 1961-Sept./Oct. 1962, May-June/July 1963)')).to.deep.equal([['1961-10', '1962-10'], ['1963-05', '1963-07']])
       expect(checkCache('1992:Feb.-Mar.')).to.deep.equal([['1992-02', '1992-03']])
+      expect(checkCache('Apr. -June 1954 (second copy)')).to.deep.equal([['1954-04', '1954-06']])
     })
     it('can handle bibs with and without fieldtagvs @local-only', async () => {
       await parseDatesAndCache(mixedBibs)

--- a/test/date-parse-test.js
+++ b/test/date-parse-test.js
@@ -24,10 +24,10 @@ describe('dateParser Lambda', () => {
   })
 
   describe('correcly parses a variety of fieldtagvs', () => {
-    it('August 2008 (second copy)', async () => {
-      const fieldtagv = 'August 2008 (second copy)'
+    it('Apr. -June 1954 (second copy) @local-only', async () => {
+      const fieldtagv = 'Apr. -June 1954 (second copy)'
       const [parsed] = await _parseDates(fieldtagv)
-      expect(parsed).to.deep.equal([['2008-08', '2008-08']])
+      expect(parsed).to.deep.equal([['1954-04', '1954-06']])
     })
     it('v. 36-37 (Nov. 1965-Oct. 1967) @local-only', async () => {
       const fieldtagv = 'v. 36-37 (Nov. 1965-Oct. 1967)'


### PR DESCRIPTION
This is my work to fix two bugs:

- field tag v including something besides a date in between parentheses ie second copy
- moving the has4digit year filter