### PR TITLE
Noref parse year

### DIFF
--- a/lib/date-parse/index.js
+++ b/lib/date-parse/index.js
@@ -55,9 +55,9 @@ const _parseOnlyYear = (dates) => {
   return dates.map((date) => {
     // tease out years format XXXX-XX
     if (date.match(theOnlyYearParsingWeNeed.matchExpression)) {
-      date = theOnlyYearParsingWeNeed.yearTransform(date)
+      date = theOnlyYearParsingWeNeed.transform(date)
     }
-    date = getAllFourDigitYears.yearTransform(date)
+    date = getAllFourDigitYears.transform(date)
     return date
   })
 }

--- a/lib/date-parse/index.js
+++ b/lib/date-parse/index.js
@@ -95,14 +95,14 @@ const _has4DigitYear = (d) => /\b\d{4}\b/.test(d)
  * @returns nothing, used for side effect of calling timetwister lambda and filling cache
  */
 
-const parseDatesAndCache = async function (bibs, sendToTimeTwister = true) {
+const parseDatesAndCache = async function (bibs, disableTimeTwister = true) {
   const dates = extractFieldtagvs(bibs)
     // remove anything that doesn't have at least a four digit year
     // (minimum for a parsable date)
     .filter(_has4DigitYear)
   try {
     let ranges
-    if (sendToTimeTwister) ranges = await _parseDates(dates)
+    if (!disableTimeTwister) ranges = await _parseDates(dates)
     else ranges = _parseOnlyYear(dates)
     dateCache = dates.reduce((cache, date, i) => {
       return { ...cache, [date]: ranges[i] }

--- a/lib/date-parse/index.js
+++ b/lib/date-parse/index.js
@@ -84,16 +84,26 @@ const _has4DigitYear = (d) => /\b\d{4}\b/.test(d)
  * @returns nothing, used for side effect of calling timetwister lambda and filling cache
  */
 
-const parseDatesAndCache = async function (bibs) {
+const parseDatesAndCache = async function (bibs, sendToTimeTwister) {
   const dates = extractFieldtagvs(bibs)
   try {
-    const ranges = await _parseDates(dates)
+    let ranges
+    if (sendToTimeTwister) ranges = await _parseDates(dates)
+    else ranges = _parseOnlyYear(dates)
     dateCache = dates.reduce((cache, date, i) => {
       return { ...cache, [date]: ranges[i] }
     }, {})
   } catch (e) {
     console.error(e)
   }
+}
+
+/**
+ * timeTwister lambda is not performant yet, so we are doing 
+ * 'local' date parsing of years only for now. 
+ */
+const _parseOnlyYear = function (dates) {
+  return years
 }
 
 /**

--- a/lib/date-parse/index.js
+++ b/lib/date-parse/index.js
@@ -2,7 +2,7 @@ const AWS = require('aws-sdk')
 const log = require('loglevel')
 const SierraItem = require('../models/item-sierra-record')
 
-const { preparsingObjects, returnOneYear } = require('./preparsingObjects')
+const { preparsingObjects, returnOneYear, theOnlyYearParsingWeNeed, getAllFourDigitYears } = require('./preparsingObjects')
 
 AWS.config.region = 'us-east-1'
 
@@ -53,32 +53,12 @@ const checkCache = (fieldtagv) => {
 const _parseOnlyYear = (dates) => {
   if (!Array.isArray(dates)) dates = [dates]
   return dates.map((date) => {
-    // do some string manipulation so data works better with timetwister lambda
-    Object.keys(preparsingObjects).forEach((preparse) => {
-      if (date.match && date.match(preparsingObjects[preparse].matchExpression)) {
-        date = preparsingObjects[preparse].yearTransform(date)
-      }
-    })
-    if (Array.isArray(date)) return date
-    else {
-      const dashSplit = date.split('-')
-      if (dashSplit[0].length === 4 && dashSplit[1].length === 4) {
-        date = [dashSplit]
-      } else {
-        if (dashSplit[0].length === 4 && dashSplit[1].length === 2) {
-          const datePrefix = dashSplit[0].slice(0, 2)
-          date = [[dashSplit[0], datePrefix + dashSplit[1]]]
-        }
-      }
-      // const slashDashMatch = date.match(/(\d{2})(\d{2})-(\d{2})\b/)
-      // if (slashDashMatch) {
-      //   const datePrefix = slashDashMatch[1]
-      //   const first = slashDashMatch[2]
-      //   const second = slashDashMatch[3]
-      //   date = [[datePrefix + first, datePrefix + second]]
-      // }
-      return date
+    // tease out years format XXXX-XX
+    if (date.match(theOnlyYearParsingWeNeed.matchExpression)) {
+      date = theOnlyYearParsingWeNeed.yearTransform(date)
     }
+    date = getAllFourDigitYears.yearTransform(date)
+    return date
   })
 }
 

--- a/lib/date-parse/index.js
+++ b/lib/date-parse/index.js
@@ -60,9 +60,9 @@ const checkCache = (fieldtagv) => {
 const preparse = function (dates) {
   return dates.map((date) => {
     // do some string manipulation so data works better with timetwister lambda
-    preparsingObjects.forEach((preparse) => {
-      if (date.match(preparse.matchExpression)) {
-        date = preparse.transform(date)
+    Object.keys(preparsingObjects).forEach((preparse) => {
+      if (date.match(preparsingObjects[preparse].matchExpression)) {
+        date = preparsingObjects[preparse].transform(date)
       }
     })
     return date
@@ -98,11 +98,11 @@ const parseDatesAndCache = async function (bibs, sendToTimeTwister) {
 }
 
 /**
- * timeTwister lambda is not performant yet, so we are doing 
- * 'local' date parsing of years only for now. 
+ * timeTwister lambda is not performant yet, so we are doing
+ * 'local' date parsing of years only for now.
  */
 const _parseOnlyYear = function (dates) {
-  return years
+  return dates
 }
 
 /**

--- a/lib/date-parse/index.js
+++ b/lib/date-parse/index.js
@@ -80,7 +80,7 @@ const _has4DigitYear = (d) => /\b\d{4}\b/.test(d)
  * @returns nothing, used for side effect of calling timetwister lambda and filling cache
  */
 
-const parseDatesAndCache = async function (bibs, sendToTimeTwister) {
+const parseDatesAndCache = async function (bibs, sendToTimeTwister = true) {
   const dates = extractFieldtagvs(bibs)
     // remove anything that doesn't have at least a four digit year
     // (minimum for a parsable date)

--- a/lib/date-parse/index.js
+++ b/lib/date-parse/index.js
@@ -50,11 +50,46 @@ const checkCache = (fieldtagv) => {
   return dateCache[fieldtagv]
 }
 
+const _parseOnlyYear = (dates) => {
+  if (!Array.isArray(dates)) dates = [dates]
+  return dates.map((date) => {
+    // do some string manipulation so data works better with timetwister lambda
+    Object.keys(preparsingObjects).forEach((preparse) => {
+      if (date.match && date.match(preparsingObjects[preparse].matchExpression)) {
+        date = preparsingObjects[preparse].yearTransform(date)
+      }
+    })
+    if (Array.isArray(date)) return date
+    else {
+      const dashSplit = date.split('-')
+      if (dashSplit[0].length === 4 && dashSplit[1].length === 4) {
+        date = [dashSplit]
+      } else {
+        if (dashSplit[0].length === 4 && dashSplit[1].length === 2) {
+          const datePrefix = dashSplit[0].slice(0, 2)
+          date = [[dashSplit[0], datePrefix + dashSplit[1]]]
+        }
+      }
+      // const slashDashMatch = date.match(/(\d{2})(\d{2})-(\d{2})\b/)
+      // if (slashDashMatch) {
+      //   const datePrefix = slashDashMatch[1]
+      //   const first = slashDashMatch[2]
+      //   const second = slashDashMatch[3]
+      //   date = [[datePrefix + first, datePrefix + second]]
+      // }
+      return date
+    }
+  })
+}
+
 /**
  *
  * @param {*} dates, an array of strings representing field tag 'v'
+ * @param year, boolean indicating whether it is preparsing dates OR
+ *  doing year parsing
  * @returns an array of those dates with some string manipulation
- *  so the data plays nicely with timetwister
+ *  so the data plays nicely with timetwister OR array of those dates
+ *  returned with the years isolated
  */
 
 const preparse = function (dates) {
@@ -95,14 +130,6 @@ const parseDatesAndCache = async function (bibs, sendToTimeTwister = true) {
   } catch (e) {
     console.error(e)
   }
-}
-
-/**
- * timeTwister lambda is not performant yet, so we are doing
- * 'local' date parsing of years only for now.
- */
-const _parseOnlyYear = function (dates) {
-  return dates
 }
 
 /**
@@ -185,4 +212,4 @@ const filterNulls = (rangesArray, preparsedDates) => {
   })
 }
 
-module.exports = { parseDatesAndCache, checkCache, private: { _parseDates, _has4DigitYear } }
+module.exports = { parseDatesAndCache, checkCache, private: { _parseDates, _has4DigitYear, _parseOnlyYear } }

--- a/lib/date-parse/preparsingObjects.js
+++ b/lib/date-parse/preparsingObjects.js
@@ -6,6 +6,7 @@
 // If timetwister returns null values, try to return a date
 const returnOneYear = {
   matchExpression: /(?:16|17|18|19|20)\d{2}/,
+  yearTransform (range) { return range },
   transform: function (range) {
     const match = range.match(this.matchExpression)
     if (match) {
@@ -21,7 +22,7 @@ const seasonPattern = `(${seasonNames.join('|')}).?`
 const monthOrSeasonPattern = `(${monthPattern}|${seasonPattern})`
 /**
  * These are objects with regex expressions and transform functions used to preparse
- * date strings before they are sent to the date parse lambda. 
+ * date strings before they are sent to the date parse lambda.
  */
 const objects = {
   // Extract values from inside parentheses; v. 5 (August 1990)
@@ -31,6 +32,9 @@ const objects = {
       const match = range.match(this.matchExpression)
       return match[1]
     },
+    yearTransform (range) {
+      return this.transform(range)
+    },
     exampleString: 'v. 5 (August 1990)'
   },
 
@@ -38,17 +42,19 @@ const objects = {
 
   colon: {
     matchExpression: new RegExp(`\\d{4}:${monthOrSeasonPattern}`, 'i'),
-    transform: function (range) {
+    transform (range) {
       return range.split(':')[1] + ' ' + range.split(':')[0]
+    },
+    yearTransform (range) {
+      return [[range.split(':')[0], range.split(':')[0]]]
     },
     exampleString: '1992:spring'
   },
 
-
   // 1956/57-1981/82
   twoYearRangeMulti: {
     matchExpression: /(?<!(no|v)\.\s?)\d{4}\/(\d{4}|\d{2})-\d{4}\/(\d{4}|\d{2})/gi,
-    transform: (ranges) => {
+    transform (ranges) {
       // turn 1956/57-1981/82 into 1956-82 and 1956/57-2001/02 into 1956-2002
       const range = ranges.match(/(\d{4})\/(\d{4}|\d{2})-\d{4}\/(\d{4}|\d{2})/)
       // Take the second capture group and the fourth, which are the first year in the string and the last.
@@ -60,11 +66,17 @@ const objects = {
       }
       return start + '-' + end
     },
+    yearTransform (range) {
+      return this.transform(range)
+    },
     exampleString: '1956/57-1981/82'
   },
   // 1895-1896/1897
   yearRangeWithSlash: {
     matchExpression: /(?<!(?:no|v)\.\s?)(\d{4}-)\d{4}\/(\d{4})/,
+    yearTransform (range) {
+      return this.transform(range)
+    },
     transform (range) {
       const years = range.match(this.matchExpression)
       return years[1] + years[2]
@@ -75,6 +87,9 @@ const objects = {
   // 1991/1992, but only if it is the only date range in the string
   soloRangeSlash: {
     matchExpression: /(?<!(?:no|v)\.?\s?)(?:^|\s|-)\d{4}\/(\d{4}|\d{2})/g,
+    yearTransform (range) {
+      return this.transform(range)
+    },
     transform: function (range) {
       const rangeMatch = range.match(this.matchExpression)
       return rangeMatch[0].replace(/\//, '-')
@@ -85,6 +100,7 @@ const objects = {
   // addressing mysterious bug in timetwister that causes null values for XX0X-0X ranges
   shortYearBug: {
     matchExpression: /(\d{4})-(0\d)/,
+    yearTransform (range) { return range },
     transform: function (range) {
       const shortYear = range.match(this.matchExpression)[2]
       const century = range.match(/^\d{2}/)[0]
@@ -96,6 +112,9 @@ const objects = {
   // month-month/month ' May-June/July 1963,  Oct. 1961-Sept./Oct. 1962'
   monthRangeWithSlash: {
     matchExpression: /(?<=-)[a-z]{3,4}\.?\/|\/[a-z]{3,4}\./gi,
+    yearTransform (range) {
+      return this.transform(range)
+    },
     transform: function (range) {
       return range.replace(this.matchExpression, '')
     },
@@ -104,6 +123,7 @@ const objects = {
 
   removeSecondCopy: {
     matchExpression: /\(second copy\)/,
+    yearTransform (range) { return this.transform(range) },
     transform: function (range) {
       return range.replace('(second copy)', '')
     }

--- a/lib/date-parse/preparsingObjects.js
+++ b/lib/date-parse/preparsingObjects.js
@@ -1,107 +1,97 @@
-/**
- * These are objects with regex expressions and transform functions used to preparse
- * date strings before they are sent to the date parse lambda
- */
-
-// If timetwister returns null values, try to return a date
-const returnOneYear = {
-  matchExpression: /(?:16|17|18|19|20)\d{2}/,
-  transform: function (range) {
-    const match = range.match(this.matchExpression)
-    if (match) {
-      return match[0]
-    }
-  }
-}
-
-// Extract values from inside parentheses; v. 5 (August 1990)
-const parens = {
-  matchExpression: /\((.+)\)/,
-  transform: function (range) {
-    const match = range.match(this.matchExpression)
-    if (match[1] === 'second copy') {
-      return range.replace('(second copy)', '')
-    } else {
-      return match[1]
-    }
-  },
-  exampleString: 'v. 5 (August 1990)'
-}
-
-// 1992:spring
 const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'June?', 'July?', 'Aug', 'Sept?', 'Oct', 'Nov', 'Dec']
 const monthPattern = `(${monthNames.join('|')}).?`
 const seasonNames = ['Win(ter)?', '(Autumn|Fall?)', 'Spr(ing)?', 'Sum(mer)?']
 const seasonPattern = `(${seasonNames.join('|')}).?`
 const monthOrSeasonPattern = `(${monthPattern}|${seasonPattern})`
-
-const colon = {
-  matchExpression: new RegExp(`\\d{4}:${monthOrSeasonPattern}`, 'i'),
-  transform: function (range) {
-    return range.split(':')[1] + ' ' + range.split(':')[0]
+/**
+ * These are objects with regex expressions and transform functions used to preparse
+ * date strings before they are sent to the date parse lambda
+ */
+const objects = {
+  // Extract values from inside parentheses; v. 5 (August 1990)
+  parens: {
+    matchExpression: /\((.+)\)/,
+    transform: function (range) {
+      const match = range.match(this.matchExpression)
+      if (match[1] === 'second copy') {
+        return range.replace('(second copy)', '')
+      } else {
+        return match[1]
+      }
+    },
+    exampleString: 'v. 5 (August 1990)'
   },
-  exampleString: '1992:spring'
-}
 
-// 1991/1992, but only if it is the only date range in the string
-const soloRangeSlash = {
-  matchExpression: /(?<!(?:no|v)\.?\s?)(?:^|\s|-)\d{4}\/(\d{4}|\d{2})/g,
-  transform: function (range) {
-    const rangeMatch = range.match(this.matchExpression)
-    return rangeMatch[0].replace(/\//, '-')
-  },
-  exampleString: '1991/1992'
-}
+  // 1992:spring
 
-// 1956/57-1981/82
-const twoYearRangeMulti = {
-  matchExpression: /(?<!(no|v)\.\s?)\d{4}\/(\d{4}|\d{2})-\d{4}\/(\d{4}|\d{2})/gi,
-  transform: (ranges) => {
-    // turn 1956/57-1981/82 into 1956-82 and 1956/57-2001/02 into 1956-2002
-    const range = ranges.match(/(\d{4})\/(\d{4}|\d{2})-\d{4}\/(\d{4}|\d{2})/)
-    // Take the second capture group and the fourth, which are the first year in the string and the last.
-    const start = range[1]
-    let end = range[3]
-    // for ranges that end up 1999-02, turn into 1999-2002
-    if (start.match(/^19/) && end.match(/^0\d/)) {
-      end = '20' + end
-    }
-    return start + '-' + end
+  colon: {
+    matchExpression: new RegExp(`\\d{4}:${monthOrSeasonPattern}`, 'i'),
+    transform: function (range) {
+      return range.split(':')[1] + ' ' + range.split(':')[0]
+    },
+    exampleString: '1992:spring'
   },
-  exampleString: '1956/57-1981/82'
-}
 
-// addressing mysterious bug in timetwister that causes null values for XX0X-0X ranges
-const shortYearBug = {
-  matchExpression: /(\d{4})-(0\d)/,
-  transform: function (range) {
-    const shortYear = range.match(this.matchExpression)[2]
-    const century = range.match(/^\d{2}/)[0]
-    return range.replace(/(?<=-)(0\d)/, century + shortYear)
+  // 1991/1992, but only if it is the only date range in the string
+  soloRangeSlash: {
+    matchExpression: /(?<!(?:no|v)\.?\s?)(?:^|\s|-)\d{4}\/(\d{4}|\d{2})/g,
+    transform: function (range) {
+      const rangeMatch = range.match(this.matchExpression)
+      return rangeMatch[0].replace(/\//, '-')
+    },
+    exampleString: '1991/1992'
   },
-  exampleString: 'XX0X-0X'
-}
 
-// month-month/month ' May-June/July 1963,  Oct. 1961-Sept./Oct. 1962'
-const monthRangeWithSlash = {
-  matchExpression: /(?<=-)[a-z]{3,4}\.?\/|\/[a-z]{3,4}\./gi,
-  transform: function (range) {
-    return range.replace(this.matchExpression, '')
+  // 1956/57-1981/82
+  twoYearRangeMulti: {
+    matchExpression: /(?<!(no|v)\.\s?)\d{4}\/(\d{4}|\d{2})-\d{4}\/(\d{4}|\d{2})/gi,
+    transform: (ranges) => {
+      // turn 1956/57-1981/82 into 1956-82 and 1956/57-2001/02 into 1956-2002
+      const range = ranges.match(/(\d{4})\/(\d{4}|\d{2})-\d{4}\/(\d{4}|\d{2})/)
+      // Take the second capture group and the fourth, which are the first year in the string and the last.
+      const start = range[1]
+      let end = range[3]
+      // for ranges that end up 1999-02, turn into 1999-2002
+      if (start.match(/^19/) && end.match(/^0\d/)) {
+        end = '20' + end
+      }
+      return start + '-' + end
+    },
+    exampleString: '1956/57-1981/82'
   },
-  exampleString: ' May-June/July 1963, Oct. 1961-Sept./Oct. 1962'
-}
 
-// 1895-1896/1897
-const yearRangeWithSlash = {
-  matchExpression: /(?<!(?:no|v)\.\s?)(\d{4}-)\d{4}\/(\d{4})/,
-  transform: function (range) {
-    const years = range.match(this.matchExpression)
-    return years[1] + years[2]
+  // addressing mysterious bug in timetwister that causes null values for XX0X-0X ranges
+  shortYearBug: {
+    matchExpression: /(\d{4})-(0\d)/,
+    transform: function (range) {
+      const shortYear = range.match(this.matchExpression)[2]
+      const century = range.match(/^\d{2}/)[0]
+      return range.replace(/(?<=-)(0\d)/, century + shortYear)
+    },
+    exampleString: 'XX0X-0X'
   },
-  exampleString: '1895-1896/1897'
+
+  // month-month/month ' May-June/July 1963,  Oct. 1961-Sept./Oct. 1962'
+  monthRangeWithSlash: {
+    matchExpression: /(?<=-)[a-z]{3,4}\.?\/|\/[a-z]{3,4}\./gi,
+    transform: function (range) {
+      return range.replace(this.matchExpression, '')
+    },
+    exampleString: ' May-June/July 1963, Oct. 1961-Sept./Oct. 1962'
+  },
+
+  // 1895-1896/1897
+  yearRangeWithSlash: {
+    matchExpression: /(?<!(?:no|v)\.\s?)(\d{4}-)\d{4}\/(\d{4})/,
+    transform (range) {
+      const years = range.match(this.matchExpression)
+      return years[1] + years[2]
+    },
+    exampleString: '1895-1896/1897'
+  }
 }
 
 module.exports = {
-  preparsingObjects: [parens, colon, twoYearRangeMulti, yearRangeWithSlash, soloRangeSlash, shortYearBug, monthRangeWithSlash],
+  preparsingObjects: objects,
   returnOneYear
 }

--- a/lib/date-parse/preparsingObjects.js
+++ b/lib/date-parse/preparsingObjects.js
@@ -5,7 +5,7 @@
 
 const getAllFourDigitYears = {
   matchExpression: /\b(\d{4})\b/g,
-  yearTransform (range) {
+  transform (range) {
     const years = [...range.matchAll(this.matchExpression)]
     if (!years.length) {
       return []
@@ -19,7 +19,7 @@ const getAllFourDigitYears = {
 
 const theOnlyYearParsingWeNeed = {
   matchExpression: /\b((?:16|17|18|19|20)\d{2})[-|/](\d{2})\b/g,
-  yearTransform (range) {
+  transform (range) {
     const years = [...range.matchAll(this.matchExpression)]
     const prefix = years[0][0].slice(0, 2)
     let secondYear
@@ -35,7 +35,6 @@ const theOnlyYearParsingWeNeed = {
 // If timetwister returns null values, try to return a date
 const returnOneYear = {
   matchExpression: /(?:16|17|18|19|20)\d{2}/,
-  yearTransform (range) { return range },
   transform: function (range) {
     const match = range.match(this.matchExpression)
     if (match) {
@@ -61,9 +60,6 @@ const wholeDateObjects = {
       const match = range.match(this.matchExpression)
       return match[1]
     },
-    yearTransform (range) {
-      return this.transform(range)
-    },
     exampleString: 'v. 5 (August 1990)'
   },
 
@@ -73,9 +69,6 @@ const wholeDateObjects = {
     matchExpression: new RegExp(`\\d{4}:${monthOrSeasonPattern}`, 'i'),
     transform (range) {
       return range.split(':')[1] + ' ' + range.split(':')[0]
-    },
-    yearTransform (range) {
-      return [[range.split(':')[0], range.split(':')[0]]]
     },
     exampleString: '1992:spring'
   },
@@ -95,17 +88,11 @@ const wholeDateObjects = {
       }
       return start + '-' + end
     },
-    yearTransform (range) {
-      return this.transform(range)
-    },
     exampleString: '1956/57-1981/82'
   },
   // 1895-1896/1897
   yearRangeWithSlash: {
     matchExpression: /(?<!(?:no|v)\.\s?)(\d{4}-)\d{4}\/(\d{4})/,
-    yearTransform (range) {
-      return this.transform(range)
-    },
     transform (range) {
       const years = range.match(this.matchExpression)
       return years[1] + years[2]
@@ -116,9 +103,6 @@ const wholeDateObjects = {
   // 1991/1992 or 1991/92 but only if it is the only date range in the string
   soloRangeSlash: {
     matchExpression: /(?<!(?:no|v)\.?\s?)(?:^|\s|-)\d{4}\/(\d{4}|\d{2})/g,
-    yearTransform (range) {
-      return this.transform(range)
-    },
     transform: function (range) {
       const rangeMatch = range.match(this.matchExpression)
       return rangeMatch[0].replace(/\//, '-')
@@ -129,7 +113,6 @@ const wholeDateObjects = {
   // addressing mysterious bug in timetwister that causes null values for XX0X-0X ranges
   shortYearBug: {
     matchExpression: /(\d{4})-(0\d)/,
-    yearTransform (range) { return range },
     transform: function (range) {
       const shortYear = range.match(this.matchExpression)[2]
       const century = range.match(/^\d{2}/)[0]
@@ -141,9 +124,6 @@ const wholeDateObjects = {
   // month-month/month ' May-June/July 1963,  Oct. 1961-Sept./Oct. 1962'
   monthRangeWithSlash: {
     matchExpression: /(?<=-)[a-z]{3,4}\.?\/|\/[a-z]{3,4}\./gi,
-    yearTransform (range) {
-      return this.transform(range)
-    },
     transform: function (range) {
       return range.replace(this.matchExpression, '')
     },
@@ -152,7 +132,6 @@ const wholeDateObjects = {
 
   removeSecondCopy: {
     matchExpression: /\(second copy\)/,
-    yearTransform (range) { return this.transform(range) },
     transform: function (range) {
       return range.replace('(second copy)', '')
     }

--- a/lib/date-parse/preparsingObjects.js
+++ b/lib/date-parse/preparsingObjects.js
@@ -53,7 +53,7 @@ const monthOrSeasonPattern = `(${monthPattern}|${seasonPattern})`
  * These are objects with regex expressions and transform functions used to preparse
  * date strings before they are sent to the date parse lambda.
  */
-const objects = {
+const wholeDateObjects = {
   // Extract values from inside parentheses; v. 5 (August 1990)
   parens: {
     matchExpression: /\((.+\b\d{4})\)/,
@@ -160,7 +160,7 @@ const objects = {
 }
 
 module.exports = {
-  preparsingObjects: objects,
+  preparsingObjects: wholeDateObjects,
   returnOneYear,
   getAllFourDigitYears,
   theOnlyYearParsingWeNeed

--- a/lib/date-parse/preparsingObjects.js
+++ b/lib/date-parse/preparsingObjects.js
@@ -8,7 +8,7 @@ const getAllFourDigitYears = {
   transform (range) {
     const years = [...range.matchAll(this.matchExpression)]
     if (!years.length) {
-      return []
+      return null
     } else if (years.length === 1) {
       return [[years[0][1], years[0][1]]]
     } else if (years.legnth === 2) {

--- a/lib/date-parse/preparsingObjects.js
+++ b/lib/date-parse/preparsingObjects.js
@@ -21,15 +21,9 @@ const seasonPattern = `(${seasonNames.join('|')}).?`
 const monthOrSeasonPattern = `(${monthPattern}|${seasonPattern})`
 /**
  * These are objects with regex expressions and transform functions used to preparse
- * date strings before they are sent to the date parse lambda
+ * date strings before they are sent to the date parse lambda. 
  */
 const objects = {
-  removeSecondCopy: {
-    matchExpression: /\(second copy\)/,
-    transform: function (range) {
-      return range.replace('(second copy)', '')
-    }
-  },
   // Extract values from inside parentheses; v. 5 (August 1990)
   parens: {
     matchExpression: /\((.+\b\d{4})\)/,
@@ -50,15 +44,6 @@ const objects = {
     exampleString: '1992:spring'
   },
 
-  // 1991/1992, but only if it is the only date range in the string
-  soloRangeSlash: {
-    matchExpression: /(?<!(?:no|v)\.?\s?)(?:^|\s|-)\d{4}\/(\d{4}|\d{2})/g,
-    transform: function (range) {
-      const rangeMatch = range.match(this.matchExpression)
-      return rangeMatch[0].replace(/\//, '-')
-    },
-    exampleString: '1991/1992'
-  },
 
   // 1956/57-1981/82
   twoYearRangeMulti: {
@@ -76,6 +61,25 @@ const objects = {
       return start + '-' + end
     },
     exampleString: '1956/57-1981/82'
+  },
+  // 1895-1896/1897
+  yearRangeWithSlash: {
+    matchExpression: /(?<!(?:no|v)\.\s?)(\d{4}-)\d{4}\/(\d{4})/,
+    transform (range) {
+      const years = range.match(this.matchExpression)
+      return years[1] + years[2]
+    },
+    exampleString: '1895-1896/1897'
+  },
+
+  // 1991/1992, but only if it is the only date range in the string
+  soloRangeSlash: {
+    matchExpression: /(?<!(?:no|v)\.?\s?)(?:^|\s|-)\d{4}\/(\d{4}|\d{2})/g,
+    transform: function (range) {
+      const rangeMatch = range.match(this.matchExpression)
+      return rangeMatch[0].replace(/\//, '-')
+    },
+    exampleString: '1991/1992'
   },
 
   // addressing mysterious bug in timetwister that causes null values for XX0X-0X ranges
@@ -98,14 +102,11 @@ const objects = {
     exampleString: ' May-June/July 1963, Oct. 1961-Sept./Oct. 1962'
   },
 
-  // 1895-1896/1897
-  yearRangeWithSlash: {
-    matchExpression: /(?<!(?:no|v)\.\s?)(\d{4}-)\d{4}\/(\d{4})/,
-    transform (range) {
-      const years = range.match(this.matchExpression)
-      return years[1] + years[2]
-    },
-    exampleString: '1895-1896/1897'
+  removeSecondCopy: {
+    matchExpression: /\(second copy\)/,
+    transform: function (range) {
+      return range.replace('(second copy)', '')
+    }
   }
 }
 

--- a/lib/date-parse/preparsingObjects.js
+++ b/lib/date-parse/preparsingObjects.js
@@ -3,6 +3,35 @@
  * date strings before they are sent to the date parse lambda
  */
 
+const getAllFourDigitYears = {
+  matchExpression: /\b(\d{4})\b/g,
+  yearTransform (range) {
+    const years = [...range.matchAll(this.matchExpression)]
+    if (!years.length) {
+      return []
+    } else if (years.length === 1) {
+      return [[years[0][1], years[0][1]]]
+    } else if (years.legnth === 2) {
+      return [years.map(year => year[1])]
+    } else return [[years[0][1], years[years.length - 1][1]]]
+  }
+}
+
+const theOnlyYearParsingWeNeed = {
+  matchExpression: /\b((?:16|17|18|19|20)\d{2})[-|/](\d{2})\b/g,
+  yearTransform (range) {
+    const years = [...range.matchAll(this.matchExpression)]
+    const prefix = years[0][0].slice(0, 2)
+    let secondYear
+    if (years.length === 1) {
+      secondYear = years[0][2]
+    } else {
+      secondYear = years[years.length - 1][2]
+    }
+    return years[0][1] + '-' + prefix + secondYear
+  }
+}
+
 // If timetwister returns null values, try to return a date
 const returnOneYear = {
   matchExpression: /(?:16|17|18|19|20)\d{2}/,
@@ -84,7 +113,7 @@ const objects = {
     exampleString: '1895-1896/1897'
   },
 
-  // 1991/1992, but only if it is the only date range in the string
+  // 1991/1992 or 1991/92 but only if it is the only date range in the string
   soloRangeSlash: {
     matchExpression: /(?<!(?:no|v)\.?\s?)(?:^|\s|-)\d{4}\/(\d{4}|\d{2})/g,
     yearTransform (range) {
@@ -132,5 +161,7 @@ const objects = {
 
 module.exports = {
   preparsingObjects: objects,
-  returnOneYear
+  returnOneYear,
+  getAllFourDigitYears,
+  theOnlyYearParsingWeNeed
 }

--- a/test/data/date-parse-bibs/v-bibs.json
+++ b/test/data/date-parse-bibs/v-bibs.json
@@ -8,6 +8,18 @@
             "marcTag": null,
             "ind1": null,
             "ind2": null,
+            "content": "Apr. -June 1954 (second copy)",
+            "subfields": null
+          }
+        ]
+      },
+      {
+        "varFields": [
+          {
+            "fieldTag": "v",
+            "marcTag": null,
+            "ind1": null,
+            "ind2": null,
             "content": "v. 36-37 (Nov. 1965-Oct. 1967)",
             "subfields": null
           }

--- a/test/date-parse-test.js
+++ b/test/date-parse-test.js
@@ -7,14 +7,14 @@ const mixedBibs = require('./data/date-parse-bibs/mixed-bibs.json')
 describe('dateParser Lambda', () => {
   describe('caching entire date', () => {
     it('caches parsed dates for bibs with fieldtagvs @local-only', async () => {
-      await parseDatesAndCache(serialBibs)
+      await parseDatesAndCache(serialBibs, false)
       expect(checkCache('v. 36-37 (Nov. 1965-Oct. 1967)')).to.deep.equal([['1965-11', '1967-10']])
       expect(checkCache('v. 6-7 no. 2, 5-v. 8 no. 1 (Oct. 1961-Sept./Oct. 1962, May-June/July 1963)')).to.deep.equal([['1961-10', '1962-10'], ['1963-05', '1963-07']])
       expect(checkCache('1992:Feb.-Mar.')).to.deep.equal([['1992-02', '1992-03']])
       expect(checkCache('Apr. -June 1954 (second copy)')).to.deep.equal([['1954-04', '1954-06']])
     })
     it('can handle bibs with and without fieldtagvs @local-only', async () => {
-      await parseDatesAndCache(mixedBibs)
+      await parseDatesAndCache(mixedBibs, false)
       const fieldtagvs = ['v. 36-37 (Nov. 1965-Oct. 1967)', '1992:Feb.-Mar.', 'v. 6-7 no. 2, 5-v. 8 no. 1 (Oct. 1961-Sept./Oct. 1962, May-June/July 1963)']
       const cachedParsedValues = fieldtagvs.map((tag) => {
         return checkCache(tag)
@@ -25,7 +25,7 @@ describe('dateParser Lambda', () => {
 
   describe('caching years', () => {
     it('parses years only - mixed bibs', async () => {
-      await parseDatesAndCache(mixedBibs, false)
+      await parseDatesAndCache(mixedBibs)
       const fieldtagvs = ['v. 36-37 (Nov. 1965-Oct. 1967)', '1992:Feb.-Mar.', 'v. 6-7 no. 2, 5-v. 8 no. 1 (Oct. 1961-Sept./Oct. 1962, May-June/July 1963)']
       const cachedParsedValues = fieldtagvs.map((tag) => {
         return checkCache(tag)
@@ -33,7 +33,7 @@ describe('dateParser Lambda', () => {
       expect(cachedParsedValues).to.deep.equal([[['1965', '1967']], [['1992', '1992']], [['1961', '1963']]])
     })
     it('caches parsed dates for bibs with fieldtagvs', async () => {
-      await parseDatesAndCache(serialBibs, false)
+      await parseDatesAndCache(serialBibs)
       expect(checkCache('v. 36-37 (Nov. 1965-Oct. 1967)')).to.deep.equal([['1965', '1967']])
       expect(checkCache('v. 6-7 no. 2, 5-v. 8 no. 1 (Oct. 1961-Sept./Oct. 1962, May-June/July 1963)')).to.deep.equal([['1961', '1963']])
       expect(checkCache('1992:Feb.-Mar.')).to.deep.equal([['1992', '1992']])

--- a/test/date-parse-test.js
+++ b/test/date-parse-test.js
@@ -132,7 +132,7 @@ describe('dateParser Lambda', () => {
     })
   })
 
-  describe.only('_parseOnlyYear', () => {
+  describe('_parseOnlyYear', () => {
     it('Apr. -June 1954 (second copy) ', async () => {
       const fieldtagv = 'Apr. -June 1954 (second copy)'
       const [parsed] = await _parseOnlyYear(fieldtagv)

--- a/test/date-parse-test.js
+++ b/test/date-parse-test.js
@@ -5,7 +5,7 @@ const serialBibs = require('./data/date-parse-bibs/v-bibs.json')
 const mixedBibs = require('./data/date-parse-bibs/mixed-bibs.json')
 
 describe('dateParser Lambda', () => {
-  describe('caching', () => {
+  describe('caching entire date', () => {
     it('caches parsed dates for bibs with fieldtagvs @local-only', async () => {
       await parseDatesAndCache(serialBibs)
       expect(checkCache('v. 36-37 (Nov. 1965-Oct. 1967)')).to.deep.equal([['1965-11', '1967-10']])
@@ -19,8 +19,25 @@ describe('dateParser Lambda', () => {
       const cachedParsedValues = fieldtagvs.map((tag) => {
         return checkCache(tag)
       })
-
       expect(cachedParsedValues).to.deep.equal([[['1965-11', '1967-10']], [['1992-02', '1992-03']], [['1961-10', '1962-10'], ['1963-05', '1963-07']]])
+    })
+  })
+
+  describe('caching years', () => {
+    it('parses years only - mixed bibs', async () => {
+      await parseDatesAndCache(mixedBibs, false)
+      const fieldtagvs = ['v. 36-37 (Nov. 1965-Oct. 1967)', '1992:Feb.-Mar.', 'v. 6-7 no. 2, 5-v. 8 no. 1 (Oct. 1961-Sept./Oct. 1962, May-June/July 1963)']
+      const cachedParsedValues = fieldtagvs.map((tag) => {
+        return checkCache(tag)
+      })
+      expect(cachedParsedValues).to.deep.equal([[['1965', '1967']], [['1992', '1992']], [['1961', '1963']]])
+    })
+    it('caches parsed dates for bibs with fieldtagvs', async () => {
+      await parseDatesAndCache(serialBibs, false)
+      expect(checkCache('v. 36-37 (Nov. 1965-Oct. 1967)')).to.deep.equal([['1965', '1967']])
+      expect(checkCache('v. 6-7 no. 2, 5-v. 8 no. 1 (Oct. 1961-Sept./Oct. 1962, May-June/July 1963)')).to.deep.equal([['1961', '1963']])
+      expect(checkCache('1992:Feb.-Mar.')).to.deep.equal([['1992', '1992']])
+      expect(checkCache('Apr. -June 1954 (second copy)')).to.deep.equal([['1954', '1954']])
     })
   })
 

--- a/test/date-parse-test.js
+++ b/test/date-parse-test.js
@@ -211,7 +211,7 @@ describe('dateParser Lambda', () => {
     it('v. 6-7 no. 2, 5-v. 8 no. 1 (Oct. 1961-Sept./Oct. 1962, May-June/July 1963) ', async () => {
       const fieldtagv = 'v. 6-7 no. 2, 5-v. 8 no. 1 (Oct. 1961-Sept./Oct. 1962, May-June/July 1963)'
       const [parsed] = await _parseOnlyYear(fieldtagv)
-      expect(parsed).to.deep.equal([['1961', '1962'], ['1963', '1963']])
+      expect(parsed).to.deep.equal([['1961', '1963']])
     })
     it('Aug. 1976 ', async () => {
       const fieldtagv = 'Aug. 1976'

--- a/test/date-parse-test.js
+++ b/test/date-parse-test.js
@@ -1,6 +1,6 @@
 /* global describe it */
 const expect = require('chai').expect
-const { parseDatesAndCache, checkCache, private: { _parseDates, _has4DigitYear } } = require('../lib/date-parse')
+const { parseDatesAndCache, checkCache, private: { _parseDates, _has4DigitYear, _parseOnlyYear } } = require('../lib/date-parse')
 const serialBibs = require('./data/date-parse-bibs/v-bibs.json')
 const mixedBibs = require('./data/date-parse-bibs/mixed-bibs.json')
 
@@ -129,6 +129,114 @@ describe('dateParser Lambda', () => {
       const fieldtagv = 'Mar. 1969-Winter 1970'
       const [parsed] = await _parseDates(fieldtagv)
       expect(parsed).to.deep.equal([['1969-03-01', '1970-03-20']])
+    })
+  })
+
+  describe.only('_parseOnlyYear', () => {
+    it('Apr. -June 1954 (second copy) ', async () => {
+      const fieldtagv = 'Apr. -June 1954 (second copy)'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['1954', '1954']])
+    })
+    it('v. 36-37 (Nov. 1965-Oct. 1967) ', async () => {
+      const fieldtagv = 'v. 36-37 (Nov. 1965-Oct. 1967)'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['1965', '1967']])
+    })
+    it('1992:Feb.-Mar. ', async () => {
+      const fieldtagv = '1992:Feb.-Mar.'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['1992', '1992']])
+    })
+    it('May 1, 1888 - Aug 31, 1888 ', async () => {
+      const fieldtagv = 'May 1, 1888 - Aug 31, 1888'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['1888', '1888']])
+    })
+    it('1969-76 ', async () => {
+      const fieldtagv = '1969-76'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['1969', '1976']])
+    })
+    it('Jan.-Dec. 1967 ', async () => {
+      const fieldtagv = 'Jan.-Dec. 1967'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['1967', '1967']])
+    })
+    it('1964-65 ', async () => {
+      const fieldtagv = '1964-65'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['1964', '1965']])
+    })
+    it('1906-09 ', async () => {
+      const fieldtagv = '1906-09'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['1906', '1909']])
+    })
+    it('2006-09 ', async () => {
+      const fieldtagv = '2006-09'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['2006', '2009']])
+    })
+    it('Jan. 2, 1964-July 29, 1965 ', async () => {
+      const fieldtagv = 'Jan. 2, 1964-July 29, 1965'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['1964', '1965']])
+    })
+    it('Nov. 1965-Oct. 1967 ', async () => {
+      const fieldtagv = 'Nov. 1965-Oct. 1967'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['1965', '1967']])
+    })
+    it('1992:Feb.-Mar ', async () => {
+      const fieldtagv = '1992:Feb.-Mar'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['1992', '1992']])
+    })
+    it('1904/1905 ', async () => {
+      const fieldtagv = '1904/1905'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['1904', '1905']])
+    })
+    it('1951/52-1959/60 ', async () => {
+      const fieldtagv = '1951/52-1959/60'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['1951', '1960']])
+    })
+    it('1934/1935-1935/1936 ', async () => {
+      const fieldtagv = '1934/1935-1935/1936'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['1934', '1936']])
+    })
+    it('v. 6-7 no. 2, 5-v. 8 no. 1 (Oct. 1961-Sept./Oct. 1962, May-June/July 1963) ', async () => {
+      const fieldtagv = 'v. 6-7 no. 2, 5-v. 8 no. 1 (Oct. 1961-Sept./Oct. 1962, May-June/July 1963)'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['1961', '1962'], ['1963', '1963']])
+    })
+    it('Aug. 1976 ', async () => {
+      const fieldtagv = 'Aug. 1976'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['1976', '1976']])
+    })
+    it('1992:spring ', async () => {
+      const fieldtagv = '1992:spring'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['1992', '1992']])
+    })
+    it('v. 93, no. 3 (autumn 2013) ', async () => {
+      const fieldtagv = 'v. 93, no. 3 (autumn 2013)'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['2013', '2013']])
+    })
+    it('v. 10, no. 1 - 4 (win. - aut. 1976) inde ', async () => {
+      const fieldtagv = 'v. 10, no. 1 - 4 (win. - aut. 1976) inde.'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['1976', '1976']])
+    })
+    it('Mar. 1969-Winter 1970 ', async () => {
+      const fieldtagv = 'Mar. 1969-Winter 1970'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['1969', '1970']])
     })
   })
 


### PR DESCRIPTION
Circumvents timetwister

- added a couple more parsing objects, but basically i'm just checking to see if anything matches the pattern 1995-96, turning those into four digit years, and then regexing out all four digit years. it is looking clunky for anything that has multiple ranges. i think timetwister was doing a lot of the heavy lifting in that department. for now, everything is going to end up with one range including the first and last years parsed from the string (heres to hoping they're always in the right order)
- included a true/false switch that determines whether to parse just year or whole date, which will be passed in as from DHI 

also included:
- refactor of the preparsing objects to be in an object themselves and to be in the correct order for accurate parsing. i thought this was more elegant than exporting them in an array, but honestly now I am not so sure. 