### PR TITLE
Invert timewister config

### DIFF
--- a/lib/date-parse/index.js
+++ b/lib/date-parse/index.js
@@ -92,17 +92,18 @@ const _has4DigitYear = (d) => /\b\d{4}\b/.test(d)
 /**
  *
  * @param {array} bibs an array of bibs with items attached
+ * @param {boolean} enableTimeTwister - Indicates whether to delegate parsing to the TimeTwister lambda
  * @returns nothing, used for side effect of calling timetwister lambda and filling cache
  */
 
-const parseDatesAndCache = async function (bibs, disableTimeTwister = true) {
+const parseDatesAndCache = async function (bibs, enableTimeTwister = false) {
   const dates = extractFieldtagvs(bibs)
     // remove anything that doesn't have at least a four digit year
     // (minimum for a parsable date)
     .filter(_has4DigitYear)
   try {
     let ranges
-    if (!disableTimeTwister) ranges = await _parseDates(dates)
+    if (enableTimeTwister) ranges = await _parseDates(dates)
     else ranges = _parseOnlyYear(dates)
     dateCache = dates.reduce((cache, date, i) => {
       return { ...cache, [date]: ranges[i] }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pcdm-store-updater",
-  "version": "1.8.7",
+  "version": "1.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pcdm-store-updater",
-      "version": "1.8.7",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@nypl/nypl-core-objects": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -46,5 +46,5 @@
   "name": "pcdm-store-updater",
   "preferGlobal": false,
   "private": false,
-  "version": "1.8.7"
+  "version": "1.9.0"
 }


### PR DESCRIPTION
Latest DHI is configured with `ENABLE_TIMETWISTER=` config (default false). Given that the default is `false`, using "enable" seems like a more intuitive control, so changing the way timetwister is enabled in DSP also.