### PR TITLE
fix year parse bug

### DIFF
--- a/lib/date-parse/index.js
+++ b/lib/date-parse/index.js
@@ -53,6 +53,9 @@ const checkCache = (fieldtagv) => {
 const _parseOnlyYear = (dates) => {
   if (!Array.isArray(dates)) dates = [dates]
   return dates.map((date) => {
+    if (date.match(preparsingObjects.parens.matchExpression)) {
+      date = preparsingObjects.parens.transform(date)
+    }
     // tease out years format XXXX-XX
     if (date.match(theOnlyYearParsingWeNeed.matchExpression)) {
       date = theOnlyYearParsingWeNeed.transform(date)

--- a/lib/date-parse/preparsingObjects.js
+++ b/lib/date-parse/preparsingObjects.js
@@ -4,7 +4,7 @@
  */
 
 const getAllFourDigitYears = {
-  matchExpression: /\b((?:16|17|18|19|20)\d{2})\b/g,
+  matchExpression: /(?<!Y)(\b((?:16|17|18|19|20)\d{2})\b)/g,
   transform (range) {
     const years = [...range.matchAll(this.matchExpression)]
     if (!years.length) {

--- a/lib/date-parse/preparsingObjects.js
+++ b/lib/date-parse/preparsingObjects.js
@@ -4,7 +4,7 @@
  */
 
 const getAllFourDigitYears = {
-  matchExpression: /(?<!Y)(\b((?:16|17|18|19|20)\d{2})\b)/g,
+  matchExpression: /\b((?:16|17|18|19|20)\d{2})\b/g,
   transform (range) {
     const years = [...range.matchAll(this.matchExpression)]
     if (!years.length) {

--- a/lib/date-parse/preparsingObjects.js
+++ b/lib/date-parse/preparsingObjects.js
@@ -4,7 +4,7 @@
  */
 
 const getAllFourDigitYears = {
-  matchExpression: /\b(\d{4})\b/g,
+  matchExpression: /\b((?:16|17|18|19|20)\d{2})\b/g,
   transform (range) {
     const years = [...range.matchAll(this.matchExpression)]
     if (!years.length) {

--- a/package.json
+++ b/package.json
@@ -46,5 +46,5 @@
   "name": "pcdm-store-updater",
   "preferGlobal": false,
   "private": false,
-  "version": "1.8.7"
+  "version": "1.9.1"
 }

--- a/test/date-parse-test.js
+++ b/test/date-parse-test.js
@@ -265,6 +265,11 @@ describe('dateParser Lambda', () => {
       const [parsed] = await _parseOnlyYear(fieldtagv)
       expect(parsed).to.deep.equal([['2008', '2008']])
     })
+    it('Apr. -June 1954 (second copy)', async () => {
+      const fieldtagv = 'Apr. -June 1954 (second copy)'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['1954', '1954']])
+    })
   })
 
   describe('_has4DigitYear', () => {

--- a/test/date-parse-test.js
+++ b/test/date-parse-test.js
@@ -260,6 +260,11 @@ describe('dateParser Lambda', () => {
       const [parsed] = await _parseOnlyYear(fieldtagv)
       expect(parsed).to.deep.equal([['2008', '2008']])
     })
+    it('v. 372, no. 1990 (Nov 22/28, 2008)', async () => {
+      const fieldtagv = 'v. 372, no. 9652 (Nov 22/28, 2008)'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['2008', '2008']])
+    })
   })
 
   describe('_has4DigitYear', () => {

--- a/test/date-parse-test.js
+++ b/test/date-parse-test.js
@@ -255,6 +255,11 @@ describe('dateParser Lambda', () => {
       const [parsed] = await _parseOnlyYear(fieldtagv)
       expect(parsed).to.deep.equal([['1969', '1970']])
     })
+    it('v. 372, no. 9652 (Nov 22/28, 2008)', async () => {
+      const fieldtagv = 'v. 372, no. 9652 (Nov 22/28, 2008)'
+      const [parsed] = await _parseOnlyYear(fieldtagv)
+      expect(parsed).to.deep.equal([['2008', '2008']])
+    })
   })
 
   describe('_has4DigitYear', () => {


### PR DESCRIPTION
addressing filtering bug that chris found. records with 4-digit volumes were being indexed as having dateranges of 2008-9854. updated regex to only capture year-like 4 digit strings, and to ignore information that is outside of parens (dates are found inside parens when they are present [most of the time 🙃 ])