### PR TITLE
Add m2CustomerCode, holdings statuses

### DIFF
--- a/lib/holding-status-mapping.js
+++ b/lib/holding-status-mapping.js
@@ -1,17 +1,26 @@
-const notAvailable = { id: 'status:na', label: 'Not Available (ReCAP)' }
-const available = { id: 'status:a', label: 'Available' }
-const bindery = { id: 'status:i', label: 'At bindery' }
+const statuses = require('@nypl/nypl-core-objects')('by-statuses')
+
+const statusEntity = (id) => {
+  return {
+    id: `status:${id}`,
+    label: statuses[id].label
+  }
+}
+
+const notAvailable = statusEntity('na')
+const available = statusEntity('a')
+const bindery = statusEntity('i')
 
 module.exports = {
   A: available,
   B: notAvailable,
   E: notAvailable,
   L: notAvailable,
-  M: { id: 'status:m', label: 'Missing' },
+  M: statusEntity('m'),
   N: notAvailable,
   O: notAvailable,
   P: available,
-  R: { id: 'status:w', label: 'Withdrawn' },
+  R: statusEntity('w'),
   S: bindery,
   T: bindery,
   U: notAvailable

--- a/lib/serializers/item.js
+++ b/lib/serializers/item.js
@@ -342,6 +342,11 @@ const fromMarcJson = async (object, datasource, bib) => {
       builder.add('nypl:recapCustomerCode', { literal: customerCode }, 0, { path: customerCodePath })
     }
 
+    // Add M2 customer code (fetched from m2-customer-code-store by DHI)
+    if (object.m2CustomerCode) {
+      builder.add('nypl:m2CustomerCode', { literal: object.m2CustomerCode })
+    }
+
     // Aeon eligibility is determined by presence of a fieldTag 'x' field that
     // starts "AEON eligible"
     const aeonSiteCode = (object.fieldTag('x') || [])


### PR DESCRIPTION
Adds rule to extract m2CustomerCode (fetched by DHI)

Also fixes small issue with holdings statuses, which were hard-coded. We want them to be NYPL-Core driven. This change should have no real change, except that status:na will now have the right NYPL-Core derived label.